### PR TITLE
Fix: Correct paths in Flatpak manifest build commands

### DIFF
--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -4,12 +4,10 @@ runtime-version: '6.7'
 sdk: org.kde.Sdk
 command: start.sh
 
-# Gives network access to the build process
 build-options:
   build-args:
     - --share=network
 
-# Corrected GUI permissions
 finish-args:
   - --share=network
   - --device=dri
@@ -19,7 +17,6 @@ finish-args:
   - --filesystem=xdg-config/rectifex:create
 
 modules:
-# Module 1: Installs the Python dependencies
   - name: python3-deps
     buildsystem: simple
     build-commands:
@@ -28,16 +25,15 @@ modules:
       - type: file
         path: app/requirements.txt
 
-  # Module 2: Installs YOUR application files
   - name: stockscreener
     buildsystem: simple
     build-commands:
-      - install -D -t /app/bin/ app/main.py app/screener_engine.py app/help_texts.py
+      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py
       - install -D -t /app/share/licenses/io.github.BioVisualizer.Rectifex/ LICENSE
-      - install -D -m 755 app/start.sh /app/bin/start.sh
-      - install -D -t /app/share/applications/ app/share/applications/io.github.BioVisualizer.Rectifex.desktop
-      - install -D -t /app/share/metainfo/ app/share/metainfo/io.github.BioVisualizer.Rectifex.appdata.xml
-      - install -D -t /app/share/icons/hicolor/scalable/apps/ app/share/icons/hicolor/scalable/apps/io.github.BioVisualizer.Rectifex.svg
+      - install -D -m 755 start.sh /app/bin/start.sh
+      - install -D -t /app/share/applications/ share/applications/io.github.BioVisualizer.Rectifex.desktop
+      - install -D -t /app/share/metainfo/ share/metainfo/io.github.BioVisualizer.Rectifex.appdata.xml
+      - install -D -t /app/share/icons/hicolor/scalable/apps/ share/icons/hicolor/scalable/apps/io.github.BioVisualizer.Rectifex.svg
       - gtk-update-icon-cache -f -t /app/share/icons/hicolor
     sources:
       - type: dir


### PR DESCRIPTION
This commit corrects the file paths within the `build-commands` section of the Flatpak manifest (`io.github.BioVisualizer.Rectifex.yml`).

The `flatpak-builder` copies the *contents* of a sourced directory (like `app/`) into the build root, not the directory itself. The previous version of the file incorrectly prefixed paths with `app/`, leading to "No such file or directory" errors during the build. This change removes the unnecessary prefixes, aligning the paths with the Flatpak build environment.