### PR TITLE
Fix: Correct all paths in Flatpak manifest

### DIFF
--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -20,20 +20,20 @@ modules:
   - name: python3-deps
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix=/app --no-user --no-build-isolation -r app/requirements.txt
+      - pip3 install --prefix=/app --no-user --no-build-isolation -r requirements.txt
     sources:
-      - type: dir
-        path: app
+      - type: file
+        path: app/requirements.txt
 
   - name: stockscreener
     buildsystem: simple
     build-commands:
-      - install -D -t /app/bin/ app/main.py app/screener_engine.py app/help_texts.py
+      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py
       - install -D -t /app/share/licenses/io.github.BioVisualizer.Rectifex/ LICENSE
-      - install -D -m 755 app/start.sh /app/bin/start.sh
-      - install -D -t /app/share/applications/ app/share/applications/io.github.BioVisualizer.Rectifex.desktop
-      - install -D -t /app/share/metainfo/ app/share/metainfo/io.github.BioVisualizer.Rectifex.appdata.xml
-      - install -D -t /app/share/icons/hicolor/scalable/apps/ app/share/icons/hicolor/scalable/apps/io.github.BioVisualizer.Rectifex.svg
+      - install -D -m 755 start.sh /app/bin/start.sh
+      - install -D -t /app/share/applications/ share/applications/io.github.BioVisualizer.Rectifex.desktop
+      - install -D -t /app/share/metainfo/ share/metainfo/io.github.BioVisualizer.Rectifex.appdata.xml
+      - install -D -t /app/share/icons/hicolor/scalable/apps/ share/icons/hicolor/scalable/apps/io.github.BioVisualizer.Rectifex.svg
       - gtk-update-icon-cache -f -t /app/share/icons/hicolor
     sources:
       - type: dir


### PR DESCRIPTION
This commit provides the final, correct paths for the flatpak-builder manifest.

- The `python3-deps` module correctly uses `-r requirements.txt` as the file is sourced to the build root.
- The `stockscreener` module correctly refers to files like `main.py` and `share/applications/...` without an `app/` prefix, as the `type: dir` source copies the *contents* of the `app` directory into the build root.

This should resolve all "cannot stat file" and "Could not open requirements file" errors during the build process.