### PR TITLE
fix(screener): Add delay to yfinance to prevent throttling

### DIFF
--- a/app/screener_engine.py
+++ b/app/screener_engine.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import configparser
 from pathlib import Path
 import os
+import time
 
 # --- Global Configuration ---
 APPROX_RATES = {
@@ -132,6 +133,7 @@ def calculate_metrics_fmp(ticker, api_key):
 
 def calculate_metrics_yfinance(ticker_symbol):
     try:
+        time.sleep(0.1) # Add a delay to avoid throttling
         ticker = yf.Ticker(ticker_symbol); info = ticker.info
         if not info or info.get('quoteType') != 'EQUITY' or info.get('marketCap') is None: return None
         currency = info.get('currency', 'N/A')


### PR DESCRIPTION
This commit fixes an issue where running multiple scans in a row would lead to fewer and fewer results, eventually returning zero. This was caused by the `yfinance` library sending too many requests too quickly, leading to the user's IP being temporarily throttled by Yahoo Finance servers.

The fix introduces a small 0.1-second delay before fetching data for each ticker when using the `yfinance` source. This paces the requests to avoid throttling and ensures that scans are reliable and repeatable.