### PR TITLE
Feat: Implement Custom Strategy Editor

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,8 +18,10 @@ from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
 from PySide6.QtCore import QThread, Signal, Qt
 from PySide6.QtGui import QAction, QColor, QBrush
 
+from PySide6.QtWidgets import (QListWidget, QGroupBox, QFormLayout, QSpinBox)
 import screener_engine
 from help_texts import HELP_TEXT_DE, HELP_TEXT_EN
+import copy
 
 # --- Configuration Handling ---
 CONFIG_DIR = Path.home() / ".config" / "rectifex"
@@ -132,6 +134,224 @@ class HelpDialog(QDialog):
             self.tab_widget.setCurrentWidget(log_tab)
         layout = QVBoxLayout(); layout.addWidget(self.tab_widget); self.setLayout(layout)
 
+class StrategyEditorDialog(QDialog):
+    def __init__(self, strategies, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Strategy Editor")
+        self.setMinimumSize(700, 500)
+
+        self.strategies = copy.deepcopy(strategies)
+        self.current_strategy_name = None
+        self.score_keys = ["Quality_Score", "Value_Score", "Growth_Score", "Momentum_Score", "Yield_Score", "Safety_Score"]
+
+        # --- Main Layout ---
+        main_layout = QVBoxLayout(self)
+        editor_layout = QHBoxLayout()
+        main_layout.addLayout(editor_layout)
+
+        # --- Left Panel: Strategy List ---
+        left_panel = QWidget()
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.addWidget(QLabel("Strategies:"))
+        self.strategy_list_widget = QListWidget()
+        left_layout.addWidget(self.strategy_list_widget)
+
+        list_button_layout = QHBoxLayout()
+        self.new_button = QPushButton("New")
+        self.copy_button = QPushButton("Copy")
+        self.delete_button = QPushButton("Delete")
+        list_button_layout.addWidget(self.new_button)
+        list_button_layout.addWidget(self.copy_button)
+        list_button_layout.addWidget(self.delete_button)
+        left_layout.addLayout(list_button_layout)
+        editor_layout.addWidget(left_panel, 1)
+
+        # --- Right Panel: Editor ---
+        self.editor_groupbox = QGroupBox("Edit Strategy")
+        self.editor_groupbox.setEnabled(False)
+        form_layout = QFormLayout(self.editor_groupbox)
+
+        self.name_input = QLineEdit()
+        form_layout.addRow("Name:", self.name_input)
+
+        self.score_spinboxes = {}
+        for key in self.score_keys:
+            spinbox = QSpinBox()
+            spinbox.setRange(0, 100)
+            spinbox.setSuffix("%")
+            spinbox.valueChanged.connect(self.update_weight_sum)
+            self.score_spinboxes[key] = spinbox
+            form_layout.addRow(key.replace('_', ' ') + ":", spinbox)
+
+        self.sum_label = QLabel("Total: 0%")
+        self.sum_label.setStyleSheet("font-weight: bold;")
+        form_layout.addRow(self.sum_label)
+        editor_layout.addWidget(self.editor_groupbox, 2)
+
+        # --- Dialog Buttons ---
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        main_layout.addWidget(self.button_box)
+
+        # --- Connections & Initial State ---
+        self.strategy_list_widget.itemSelectionChanged.connect(self.on_strategy_selection_changed)
+        self.name_input.textChanged.connect(self.on_name_changed)
+        self.new_button.clicked.connect(self.new_strategy)
+        self.copy_button.clicked.connect(self.copy_strategy)
+        self.delete_button.clicked.connect(self.delete_strategy)
+        self.button_box.accepted.connect(self.on_accept)
+        self.button_box.rejected.connect(self.reject)
+
+        self.populate_strategy_list()
+
+    def populate_strategy_list(self, select_name=None):
+        self.strategy_list_widget.blockSignals(True)
+        self.strategy_list_widget.clear()
+        for name in sorted(self.strategies.keys()):
+            self.strategy_list_widget.addItem(name)
+            if name == select_name:
+                self.strategy_list_widget.setCurrentRow(self.strategy_list_widget.count() - 1)
+        self.strategy_list_widget.blockSignals(False)
+        if self.strategy_list_widget.currentItem():
+            self.on_strategy_selection_changed()
+        else:
+            self.editor_groupbox.setEnabled(False)
+
+
+    def on_strategy_selection_changed(self):
+        selected_items = self.strategy_list_widget.selectedItems()
+        if not selected_items:
+            self.current_strategy_name = None
+            self.editor_groupbox.setEnabled(False)
+            return
+
+        new_name = selected_items[0].text()
+        if self.current_strategy_name and self.current_strategy_name != new_name:
+            self.save_current_editor_state()
+
+        self.current_strategy_name = new_name
+        self.load_strategy_into_editor()
+
+    def load_strategy_into_editor(self):
+        if not self.current_strategy_name: return
+
+        strategy_data = self.strategies[self.current_strategy_name]
+        is_predefined = strategy_data.get("predefined", False)
+
+        self.name_input.setText(self.current_strategy_name)
+        self.name_input.setReadOnly(is_predefined)
+        self.delete_button.setEnabled(not is_predefined)
+        self.editor_groupbox.setEnabled(True)
+
+        for key, spinbox in self.score_spinboxes.items():
+            spinbox.blockSignals(True)
+            spinbox.setValue(int(strategy_data.get("weights", {}).get(key, 0) * 100))
+            spinbox.blockSignals(False)
+
+        self.update_weight_sum()
+
+    def save_current_editor_state(self):
+        if not self.current_strategy_name: return
+
+        old_name = self.current_strategy_name
+        new_name = self.name_input.text()
+
+        if not new_name:
+             # User cleared the name field, revert to old name to avoid issues
+            self.name_input.setText(old_name)
+            new_name = old_name
+
+        strategy_data = self.strategies.pop(old_name)
+        strategy_data["weights"] = {key: spinbox.value() / 100.0 for key, spinbox in self.score_spinboxes.items()}
+        self.strategies[new_name] = strategy_data
+        self.current_strategy_name = new_name
+
+
+    def on_name_changed(self, new_name):
+        if not self.current_strategy_name: return
+
+        selected_items = self.strategy_list_widget.selectedItems()
+        if not selected_items: return
+
+        # Prevent renaming to an existing name
+        if new_name != self.current_strategy_name and new_name in self.strategies:
+            self.name_input.setStyleSheet("color: red;")
+        else:
+            self.name_input.setStyleSheet("")
+
+        selected_items[0].setText(new_name)
+
+
+    def update_weight_sum(self):
+        total_weight = sum(spinbox.value() for spinbox in self.score_spinboxes.values())
+        self.sum_label.setText(f"Total: {total_weight}%")
+        if total_weight != 100:
+            self.sum_label.setStyleSheet("color: red; font-weight: bold;")
+        else:
+            self.sum_label.setStyleSheet("color: green; font-weight: bold;")
+
+    def new_strategy(self):
+        self.save_current_editor_state()
+        base_name = "New Strategy"
+        name = base_name
+        i = 1
+        while name in self.strategies:
+            name = f"{base_name} {i}"
+            i += 1
+
+        self.strategies[name] = {"weights": {key: 0 for key in self.score_keys}, "predefined": False}
+        self.populate_strategy_list(select_name=name)
+
+    def copy_strategy(self):
+        if not self.current_strategy_name: return
+        self.save_current_editor_state()
+
+        base_name = f"{self.current_strategy_name} (Copy)"
+        name = base_name
+        i = 1
+        while name in self.strategies:
+            name = f"{base_name} {i}"
+            i += 1
+
+        original_strategy = self.strategies[self.current_strategy_name]
+        self.strategies[name] = {
+            "weights": original_strategy["weights"].copy(),
+            "predefined": False
+        }
+        self.populate_strategy_list(select_name=name)
+
+    def delete_strategy(self):
+        if not self.current_strategy_name or self.strategies[self.current_strategy_name].get("predefined", False):
+            return
+
+        reply = QMessageBox.question(self, "Confirm Deletion", f"Are you sure you want to delete '{self.current_strategy_name}'?")
+        if reply == QMessageBox.Yes:
+            del self.strategies[self.current_strategy_name]
+            self.current_strategy_name = None
+            self.populate_strategy_list()
+
+    def on_accept(self):
+        self.save_current_editor_state()
+
+        invalid_strategies = []
+        for name, data in self.strategies.items():
+            total_weight = sum(data.get("weights", {}).values())
+            if not (0.999 < total_weight < 1.001):
+                invalid_strategies.append(name)
+
+        if invalid_strategies:
+            QMessageBox.warning(self, "Invalid Weights", "The following strategies do not have weights summing to 100%:\n\n" + "\n".join(invalid_strategies))
+            return
+
+        # Check for duplicate names
+        if len(self.strategies.keys()) != len(set(self.strategies.keys())):
+             QMessageBox.warning(self, "Duplicate Names", "Strategy names must be unique.")
+             return
+
+        self.accept()
+
+    def get_updated_strategies(self):
+        return self.strategies
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__(); self.setWindowTitle("Rectifex - Global Stock Screener"); self.setGeometry(100, 100, 1200, 800); self.result_df = None
@@ -143,7 +363,7 @@ class MainWindow(QMainWindow):
         self.strategy_label = QLabel("Analysis Strategy:")
         self.strategy_definitions = screener_engine.get_strategy_definitions()
         self.strategy_combo = QComboBox()
-        self.strategy_combo.addItems(self.strategy_definitions.keys())
+        self.strategy_combo.addItems(sorted(self.strategy_definitions.keys()))
         self.strategy_combo.currentTextChanged.connect(self.update_strategy_tooltip)
         self.update_strategy_tooltip(self.strategy_combo.currentText())
 
@@ -178,6 +398,41 @@ class MainWindow(QMainWindow):
         main_layout.addLayout(top_bar_layout); main_layout.addWidget(self.progress_bar); main_layout.addWidget(self.results_table)
         central_widget = QWidget(); central_widget.setLayout(main_layout); self.setCentralWidget(central_widget)
         self.setStatusBar(QStatusBar(self))
+        self.create_menus()
+
+    def create_menus(self):
+        menu_bar = self.menuBar()
+        file_menu = menu_bar.addMenu("&File")
+
+        manage_strategies_action = QAction("Manage Strategies...", self)
+        manage_strategies_action.triggered.connect(self.open_strategy_editor)
+        file_menu.addAction(manage_strategies_action)
+
+        file_menu.addSeparator()
+
+        exit_action = QAction("Exit", self)
+        exit_action.triggered.connect(self.close)
+        file_menu.addAction(exit_action)
+
+    def open_strategy_editor(self):
+        dialog = StrategyEditorDialog(self.strategy_definitions, self)
+        if dialog.exec():
+            self.strategy_definitions = dialog.get_updated_strategies()
+            screener_engine.save_strategy_definitions(self.strategy_definitions)
+            self.refresh_strategy_combo()
+            self.statusBar().showMessage("Strategies saved successfully.", 5000)
+
+    def refresh_strategy_combo(self):
+        current_selection = self.strategy_combo.currentText()
+        self.strategy_combo.blockSignals(True)
+        self.strategy_combo.clear()
+        self.strategy_combo.addItems(sorted(self.strategy_definitions.keys()))
+
+        if current_selection in self.strategy_definitions:
+            self.strategy_combo.setCurrentText(current_selection)
+
+        self.strategy_combo.blockSignals(False)
+        self.update_strategy_tooltip(self.strategy_combo.currentText())
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self)
@@ -294,8 +549,11 @@ class MainWindow(QMainWindow):
 
     def update_strategy_tooltip(self, strategy_name):
         if strategy_name in self.strategy_definitions:
-            weights = self.strategy_definitions[strategy_name]
+            strategy_data = self.strategy_definitions[strategy_name]
+            weights = strategy_data.get("weights", {})
             tooltip_parts = [f"<b>{strategy_name} Strategy Weights:</b>", "<hr>"]
+            if not weights:
+                tooltip_parts.append("No weights defined.")
             for score, weight in weights.items():
                 clean_score = score.replace('_', ' ')
                 percent = f"{weight:.0%}"

--- a/app/screener_engine.py
+++ b/app/screener_engine.py
@@ -8,6 +8,7 @@ import configparser
 from pathlib import Path
 import os
 import time
+import json
 
 # --- Global Configuration ---
 APPROX_RATES = {
@@ -16,15 +17,49 @@ APPROX_RATES = {
     'NOK': 0.094, 'INR': 0.012, 'KRW': 0.00072, 'CNY': 0.14, 'GBp': 0.0127
 }
 
-STRATEGY_DEFINITIONS = {
-    "Balanced": {'Quality_Score': 0.30, 'Value_Score': 0.25, 'Growth_Score': 0.20, 'Momentum_Score': 0.10, 'Yield_Score': 0.10, 'Safety_Score': 0.05},
-    "Deep_Value": {'Value_Score': 0.70, 'Safety_Score': 0.20, 'Yield_Score': 0.10},
-    "High_Growth": {'Growth_Score': 0.60, 'Quality_Score': 0.30, 'Momentum_Score': 0.10},
-    "Quality_Dividend": {'Yield_Score': 0.50, 'Quality_Score': 0.30, 'Safety_Score': 0.20}
-}
+CONFIG_DIR = Path.home() / ".config" / "rectifex"
+STRATEGIES_FILE = CONFIG_DIR / "strategies.json"
 
 def get_strategy_definitions():
-    return STRATEGY_DEFINITIONS
+    """
+    Loads strategy definitions from strategies.json.
+    If the file doesn't exist, it creates a default one.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if not STRATEGIES_FILE.exists():
+        default_strategies = {
+          "Balanced": {
+            "weights": {"Quality_Score": 0.30, "Value_Score": 0.25, "Growth_Score": 0.20, "Momentum_Score": 0.10, "Yield_Score": 0.10, "Safety_Score": 0.05},
+            "predefined": True
+          },
+          "Deep Value": {
+            "weights": {"Value_Score": 0.70, "Safety_Score": 0.20, "Yield_Score": 0.10},
+            "predefined": True
+          },
+          "High Growth": {
+            "weights": {"Growth_Score": 0.60, "Quality_Score": 0.30, "Momentum_Score": 0.10},
+            "predefined": True
+          },
+          "Quality Dividend": {
+            "weights": {"Yield_Score": 0.50, "Quality_Score": 0.30, "Safety_Score": 0.20},
+            "predefined": True
+          }
+        }
+        save_strategy_definitions(default_strategies)
+        return default_strategies
+    else:
+        with open(STRATEGIES_FILE, 'r') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                logging.error("Could not decode strategies.json. Returning empty dict.")
+                return {}
+
+def save_strategy_definitions(strategies):
+    """Saves the strategy definitions to strategies.json."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(STRATEGIES_FILE, 'w') as f:
+        json.dump(strategies, f, indent=4)
 
 def get_global_top_tickers():
     # This list is a combination of the original tickers and a sample of new tickers from major indices.
@@ -262,15 +297,17 @@ def run_complete_screener(strategy, tickers, api_key, progress_callback):
                 score_sum += df[rank_col].fillna(50) * weight
         df[style] = 100 - score_sum
 
-    for strat_name, weights in STRATEGY_DEFINITIONS.items():
+    strategy_definitions = get_strategy_definitions()
+    for strat_name, strat_data in strategy_definitions.items():
         score_sum = pd.Series(0, index=df.index, dtype=float)
+        weights = strat_data.get('weights', {})
         for score, weight in weights.items():
             if score in df.columns:
                 score_sum += df[score].fillna(50) * weight
         df[strat_name] = score_sum
 
     for col in df.columns:
-        if '_Score' in col or col in STRATEGY_DEFINITIONS: df[col] = df[col].round(1)
+        if '_Score' in col or col in strategy_definitions: df[col] = df[col].round(1)
 
     display_columns = ['Name','Ticker','Country','Sector',strategy,'Quality_Score','Value_Score','Growth_Score','Momentum_Score','Yield_Score','Safety_Score','MarketCapUSD','PE','PB','ROE_Avg3Y','RevGrowth3YCAGR','DivYield']
     final_df = df.sort_values(by=strategy, ascending=False)

--- a/app/start.sh
+++ b/app/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 /app/bin/main.py
+python3 app/main.py


### PR DESCRIPTION
This commit introduces the Custom Strategy Editor, a major new feature that transforms the application from a static screener to a more dynamic platform.

Key changes include:
- Externalized Strategies: Strategy definitions are now stored in a `strategies.json` file.
- Strategy Editor Dialog: A new UI allows users to create, copy, edit, and delete strategies.
- UI Integration: The editor is accessible via a new "File -> Manage Strategies" menu.
- Backend Refactoring: The screening engine now uses the new JSON-based strategy definitions.