### PR TITLE
feat: Add integrated technical analysis charting module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Rectifex is a tool for **relative analysis**. It answers the question: *"Which c
 
 ## Features
 
+*   **Integrated Chart Analysis:** Go from screening to analysis in a single click. Every stock now features an integrated technical chart, showing price action (Candlesticks), key trends (50 & 200-day SMAs), and momentum indicators (RSI & MACD) to help you assess not just *what* is undervalued, but also *when* an entry point might be opportune.
 *   **Multi-Strategy Analysis:** Choose from four predefined strategies (`Balanced`, `High Growth`, `Deep Value`, `Quality Dividend`) to sort the results based on your focus.
 *   **Global Stock Universe:** Analyzes a curated list of nearly 200 leading companies from North America, Europe, and Asia.
 *   **6-Factor Model:** Every stock is evaluated across six fundamental dimensions based on proven financial metrics.

--- a/app/help_texts.py
+++ b/app/help_texts.py
@@ -104,4 +104,6 @@ For example, a high `Value_Score` only means that a stock is *quantitatively* ch
 ## Disclaimer
 
 This program is for educational and informational purposes only. The results **do not constitute investment advice or a recommendation to buy or sell.** All data is sourced from third-party APIs (`yfinance`) and may contain errors. Any investment decision based on this data is made solely at your own risk. **Never make an investment decision based on this app alone.**
+
+The inclusion of technical charts and indicators is for educational and informational purposes only and serves to provide additional context to the fundamental data. These tools do not constitute investment advice or a recommendation to buy or sell. Price trends and indicator signals may be misleading, and past performance is not indicative of future results. Any investment decision based on the combination of fundamental and technical data presented in this application is made solely at your own risk.
 """

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,10 @@ from PySide6.QtGui import QAction, QColor, QBrush
 import screener_engine
 from help_texts import HELP_TEXT_DE, HELP_TEXT_EN
 import copy
+import technical_analyzer
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
 
 # --- Configuration Handling ---
 CONFIG_DIR = Path.home() / ".config" / "rectifex"
@@ -68,6 +72,21 @@ class SettingsDialog(QDialog):
     def accept(self):
         save_api_key(self.api_key_input.text())
         super().accept()
+
+class ChartDialog(QDialog):
+    """A dialog to display a Matplotlib chart."""
+    def __init__(self, fig: Figure, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Technical Analysis Chart")
+        self.setMinimumSize(900, 700) # Adjusted size
+        self.setModal(False) # Allow interacting with main window
+
+        layout = QVBoxLayout()
+        canvas = FigureCanvas(fig)
+        canvas.setParent(self)
+        layout.addWidget(canvas)
+
+        self.setLayout(layout)
 
 class ScanWorker(QThread):
     progress = Signal(int); finished = Signal(object)
@@ -358,6 +377,7 @@ class MainWindow(QMainWindow):
         self.current_tickers = screener_engine.get_global_top_tickers()
         self.scan_errors = []
         self.api_key = load_api_key()
+        self.chart_cache = {}
 
         main_layout = QVBoxLayout(); top_bar_layout = QHBoxLayout(); controls_layout = QHBoxLayout()
         self.strategy_label = QLabel("Analysis Strategy:")
@@ -393,6 +413,8 @@ class MainWindow(QMainWindow):
         top_bar_layout.addLayout(action_layout)
         self.progress_bar = QProgressBar(); self.progress_bar.setVisible(False)
         self.results_table = QTableWidget(); self.results_table.setEditTriggers(QTableWidget.NoEditTriggers); self.results_table.setSortingEnabled(True); self.results_table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
+        self.results_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.results_table.cellDoubleClicked.connect(self.show_chart_for_ticker)
         self.results_table.setContextMenuPolicy(Qt.CustomContextMenu)
         self.results_table.customContextMenuRequested.connect(self.show_context_menu)
         main_layout.addLayout(top_bar_layout); main_layout.addWidget(self.progress_bar); main_layout.addWidget(self.results_table)
@@ -511,6 +533,45 @@ class MainWindow(QMainWindow):
                 self.results_table.setItem(r_idx, c_idx, item)
 
         self.results_table.resizeColumnsToContents(); self.results_table.setSortingEnabled(True)
+
+    def show_chart_for_ticker(self, row, column):
+        """Handles the double-click event on the table to show a chart."""
+        if self.result_df is None or row >= len(self.result_df):
+            return
+
+        try:
+            # Find the 'Ticker' column index and get the ticker symbol
+            header_labels = [self.results_table.horizontalHeaderItem(i).text() for i in range(self.results_table.columnCount())]
+            ticker_col_idx = header_labels.index("Ticker")
+            ticker = self.results_table.item(row, ticker_col_idx).text()
+        except (ValueError, AttributeError):
+            self.statusBar().showMessage("Could not find 'Ticker' column or row.", 5000)
+            return
+
+        self.statusBar().showMessage(f"Loading chart for {ticker}...", 2000)
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+
+        try:
+            if ticker in self.chart_cache:
+                fig = self.chart_cache[ticker]
+                self.statusBar().showMessage(f"Showing cached chart for {ticker}.", 5000)
+            else:
+                fig = technical_analyzer.generate_analysis_figure(ticker)
+                if fig:
+                    self.chart_cache[ticker] = fig
+                    self.statusBar().showMessage(f"Successfully loaded chart for {ticker}.", 5000)
+                else:
+                    self.statusBar().showMessage(f"Failed to generate chart for {ticker}.", 8000)
+                    QMessageBox.warning(self, "Chart Error", f"Could not generate the technical analysis chart for {ticker}.")
+                    return
+
+            # Create and show the chart dialog
+            dialog = ChartDialog(fig, self)
+            dialog.show() # Use show() for non-modal dialog
+
+        finally:
+            QApplication.restoreOverrideCursor()
+
 
     def show_context_menu(self, pos):
         if self.results_table.rowCount() == 0: return

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,5 @@ yfinance
 numpy
 PySide6
 requests
+matplotlib
+mplfinance

--- a/app/technical_analyzer.py
+++ b/app/technical_analyzer.py
@@ -1,0 +1,126 @@
+import yfinance as yf
+import pandas as pd
+import mplfinance as mpf
+import matplotlib.figure
+
+def _calculate_technical_indicators(ticker_symbol: str, period: str = "1y"):
+    """
+    Internal function to fetch historical data and calculate indicators.
+    """
+    try:
+        # Fetch historical data using yfinance, hide progress bar
+        data = yf.download(ticker_symbol, period=period, auto_adjust=True, progress=False)
+
+        if data.empty:
+            print(f"Error: No data downloaded for {ticker_symbol}. It might be an invalid ticker.")
+            return None
+
+        # Handle potential MultiIndex columns and standardize to Title Case
+        if isinstance(data.columns, pd.MultiIndex):
+            data.columns = data.columns.get_level_values(0)
+        data.columns = [str(col).title() for col in data.columns]
+
+        # --- Calculate Indicators ---
+        data['SMA50'] = data['Close'].rolling(window=50).mean()
+        data['SMA200'] = data['Close'].rolling(window=200).mean()
+
+        delta = data['Close'].diff(1)
+        gain = delta.where(delta > 0, 0.0)
+        loss = -delta.where(delta < 0, 0.0)
+        avg_gain = gain.ewm(com=13, adjust=False).mean()
+        avg_loss = loss.ewm(com=13, adjust=False).mean()
+        rs = avg_gain / avg_loss.replace(0, 0.01)
+        data['RSI'] = 100 - (100 / (1 + rs))
+
+        exp12 = data['Close'].ewm(span=12, adjust=False).mean()
+        exp26 = data['Close'].ewm(span=26, adjust=False).mean()
+        data['MACD'] = exp12 - exp26
+        data['MACD_Signal'] = data['MACD'].ewm(span=9, adjust=False).mean()
+        data['MACD_Hist'] = data['MACD'] - data['MACD_Signal']
+
+        return data
+
+    except Exception as e:
+        print(f"An error occurred in _calculate_technical_indicators for {ticker_symbol}: {e}")
+        return None
+
+def generate_analysis_figure(ticker_symbol: str, period: str = "1y") -> matplotlib.figure.Figure | None:
+    """
+    Fetches data, calculates indicators, and generates a technical analysis chart.
+
+    Args:
+        ticker_symbol (str): The stock ticker symbol.
+        period (str): The period for the data (e.g., "1y").
+
+    Returns:
+        matplotlib.figure.Figure: The figure object containing the plot, or None on failure.
+    """
+    data = _calculate_technical_indicators(ticker_symbol, period)
+    if data is None:
+        return None
+
+    # Ensure OHLCV columns are numeric
+    ohlcv_cols = ['Open', 'High', 'Low', 'Close', 'Volume']
+    cols_to_convert = [col for col in ohlcv_cols if col in data.columns]
+
+    if cols_to_convert:
+        data[cols_to_convert] = data[cols_to_convert].apply(pd.to_numeric, errors='coerce')
+
+    # Drop rows with NaN in essential columns for plotting
+    data.dropna(subset=['Open', 'High', 'Low', 'Close', 'Volume'], inplace=True)
+
+    if data.empty:
+        print(f"Error: No valid plot data for {ticker_symbol} after cleaning.")
+        return None
+
+    # Define additional plots for RSI and MACD
+    add_plots = [
+        # Panel 2: RSI
+        mpf.make_addplot(data['RSI'], panel=2, color='orange', ylabel='RSI', ylim=(10, 90)),
+        mpf.make_addplot(pd.Series(70, index=data.index), panel=2, color='r', linestyle='--', secondary_y=False),
+        mpf.make_addplot(pd.Series(30, index=data.index), panel=2, color='g', linestyle='--', secondary_y=False),
+
+        # Panel 3: MACD
+        mpf.make_addplot(data['MACD_Hist'], type='bar', panel=3, color='dimgray', ylabel='MACD'),
+        mpf.make_addplot(data['MACD'], panel=3, color='blue'),
+        mpf.make_addplot(data['MACD_Signal'], panel=3, color='red'),
+    ]
+
+    # Create the plot using mplfinance
+    try:
+        fig, axlist = mpf.plot(
+            data,
+            type='candle',
+            style='yahoo',
+            title=f'\n{ticker_symbol} Technical Analysis',
+            ylabel='Price',
+            volume=True,
+            mav=(50, 200),
+            addplot=add_plots,
+            panel_ratios=(6, 1, 2, 2),  # Ratios for main, volume, RSI, MACD
+            figscale=1.2,
+            returnfig=True
+        )
+        # Improve layout
+        fig.tight_layout()
+        return fig
+    except Exception as e:
+        print(f"Error during mplfinance plot generation for {ticker_symbol}: {e}")
+        return None
+
+if __name__ == '__main__':
+    # This block allows for standalone testing of this module
+    test_ticker = 'MSFT'
+    print(f"--- Testing chart generation for ticker: {test_ticker} ---")
+
+    figure = generate_analysis_figure(test_ticker)
+
+    if figure is not None:
+        try:
+            output_path = "test_chart.png"
+            figure.savefig(output_path, bbox_inches='tight')
+            print(f"Chart generation successful. Figure saved to '{output_path}'")
+        except Exception as e:
+            print(f"--- Test failed: Could not save figure. Error: {e} ---")
+    else:
+        print(f"--- Test failed: Could not generate chart for {test_ticker} ---")


### PR DESCRIPTION
This commit introduces a major new feature: an integrated technical analysis module that allows users to view detailed financial charts for any stock in the screener results.

This addresses the user's goal of evolving the application from a "what to buy" screener to a "when to buy" analysis tool.

Key features implemented:
- A new `technical_analyzer.py` module encapsulates all logic for data fetching (from yfinance) and chart generation (using mplfinance).
- The main GUI (`main.py`) now listens for a double-click event on the results table.
- A double-click on a stock row opens a new dialog window displaying a detailed technical chart.
- The chart includes:
  - Candlestick price action (OHLC)
  - Trading volume
  - 50-day and 200-day Simple Moving Averages (SMAs)
  - Relative Strength Index (RSI) indicator subplot
  - Moving Average Convergence Divergence (MACD) indicator subplot
- A simple in-memory cache has been added to store recently generated charts, improving performance and reducing API calls for repeated views.
- The project's README and disclaimer have been updated to reflect the new functionality.
- Dependencies (`matplotlib`, `mplfinance`) have been added to `requirements.txt`.