### PR TITLE
fix: Include technical_analyzer.py in Flatpak build

### DIFF
--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -28,7 +28,7 @@ modules:
   - name: stockscreener
     buildsystem: simple
     build-commands:
-      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py
+      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py technical_analyzer.py
       - install -D -t /app/share/licenses/io.github.BioVisualizer.Rectifex/ LICENSE
       - install -D -m 755 start.sh /app/bin/start.sh
       - install -D -t /app/share/applications/ share/applications/io.github.BioVisualizer.Rectifex.desktop


### PR DESCRIPTION
The previous commit was missing the new 'technical_analyzer.py' file in the Flatpak build commands within the .yml manifest. This caused a 'ModuleNotFoundError' when running the packaged application.

This commit adds the missing file to the install command, fixing the runtime error.