### PR TITLE
fix: Correct strategy column naming to resolve KeyError

### DIFF
--- a/app/screener_engine.py
+++ b/app/screener_engine.py
@@ -304,10 +304,14 @@ def run_complete_screener(strategy, tickers, api_key, progress_callback):
         for score, weight in weights.items():
             if score in df.columns:
                 score_sum += df[score].fillna(50) * weight
-        df[strat_name] = score_sum
 
+        column_name = strat_name.replace(" ", "_")
+        df[column_name] = score_sum
+
+    # Create a set of strategy names with underscores for quick lookup
+    strategy_column_names = {s.replace(" ", "_") for s in strategy_definitions.keys()}
     for col in df.columns:
-        if '_Score' in col or col in strategy_definitions: df[col] = df[col].round(1)
+        if '_Score' in col or col in strategy_column_names: df[col] = df[col].round(1)
 
     display_columns = ['Name','Ticker','Country','Sector',strategy,'Quality_Score','Value_Score','Growth_Score','Momentum_Score','Yield_Score','Safety_Score','MarketCapUSD','PE','PB','ROE_Avg3Y','RevGrowth3YCAGR','DivYield']
     final_df = df.sort_values(by=strategy, ascending=False)


### PR DESCRIPTION
Fixes a bug where a KeyError would occur during a 'Deep Value' scan (and other scans with spaces in their names). The issue was caused by a mismatch between the column name created in the DataFrame (e.g., "Deep Value") and the name used for sorting (e.g., "Deep_Value").

This commit ensures that strategy score columns are created with underscores, aligning them with the rest of the logic.