### PR TITLE
feat: Add stoppable scans and index-based ticker selection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,8 +100,17 @@ class ScanWorker(QThread):
         self.strategy = strategy
         self.tickers = tickers
         self.api_key = api_key
+        self._stopped = False
+
     def run(self):
-        self.finished.emit(screener_engine.run_complete_screener(self.strategy, self.tickers, self.api_key, self.progress))
+        self.finished.emit(screener_engine.run_complete_screener(self.strategy, self.tickers, self.api_key, self.progress, worker=self))
+
+    def stop(self):
+        """Stops the thread."""
+        self._stopped = True
+
+    def is_stopped(self):
+        return self._stopped
 
 class TickerManagerDialog(QDialog):
     def __init__(self, current_tickers, parent=None):
@@ -379,11 +388,13 @@ class StrategyEditorDialog(QDialog):
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__(); self.setWindowTitle("Rectifex - Global Stock Screener"); self.setGeometry(100, 100, 1200, 800); self.result_df = None
-        self.current_tickers = screener_engine.get_global_top_tickers()
+        self.current_tickers = screener_engine.get_default_tickers()
         self.scan_errors = []
         self.api_key = load_api_key()
         self.chart_cache = {}
         self.search_col_indices = None # To cache search column indices
+        self.worker = None
+        self.is_scanning = False
 
         main_layout = QVBoxLayout(); top_bar_layout = QHBoxLayout(); controls_layout = QHBoxLayout()
         self.strategy_label = QLabel("Analysis Strategy:")
@@ -394,19 +405,26 @@ class MainWindow(QMainWindow):
         self.update_strategy_tooltip(self.strategy_combo.currentText())
 
         self.scan_button = QPushButton("Start Scan")
-        self.manage_tickers_button = QPushButton("Manage Tickers")
         self.save_csv_button = QPushButton("Save as CSV"); self.save_csv_button.setEnabled(False)
+
+        # --- Ticker Source Selection ---
+        self.ticker_source_label = QLabel("Ticker Source:")
+        self.ticker_source_combo = QComboBox()
+        self.ticker_source_combo.addItems(["Default List", "S&P 500", "Nasdaq 100", "Dow Jones", "Custom List"])
+        self.ticker_source_combo.currentIndexChanged.connect(self.on_ticker_source_changed)
+        self.manage_tickers_button = QPushButton("Manage Custom List")
+        self.manage_tickers_button.setEnabled(False)
+        self.manage_tickers_button.clicked.connect(self.open_ticker_dialog)
 
         action_layout = QHBoxLayout()
         action_layout.addLayout(controls_layout)
-
         action_layout.addStretch()
 
         self.search_bar = QLineEdit()
         self.search_bar.setPlaceholderText("Search by Name or Ticker...")
         self.search_bar.setMaximumWidth(300)
         self.search_bar.textChanged.connect(self.filter_results_table)
-        self.search_bar.setEnabled(False) # Initially disabled
+        self.search_bar.setEnabled(False)
         action_layout.addWidget(self.search_bar)
 
         self.settings_button = QPushButton("Settings")
@@ -416,12 +434,14 @@ class MainWindow(QMainWindow):
         action_layout.addWidget(self.settings_button)
         action_layout.addWidget(self.help_button)
 
-        self.scan_button.clicked.connect(self.start_scan)
-        self.manage_tickers_button.clicked.connect(self.open_ticker_dialog)
+        self.scan_button.clicked.connect(self.handle_scan_click)
         self.save_csv_button.clicked.connect(self.save_as_csv)
 
         controls_layout.addWidget(self.strategy_label); controls_layout.addWidget(self.strategy_combo)
-        controls_layout.addWidget(self.scan_button); controls_layout.addWidget(self.manage_tickers_button)
+        controls_layout.addWidget(self.ticker_source_label)
+        controls_layout.addWidget(self.ticker_source_combo)
+        controls_layout.addWidget(self.manage_tickers_button)
+        controls_layout.addWidget(self.scan_button)
         controls_layout.addWidget(self.save_csv_button)
 
         top_bar_layout.addLayout(action_layout)
@@ -482,15 +502,65 @@ class MainWindow(QMainWindow):
             self.current_tickers = dialog.get_tickers()
             self.statusBar().showMessage(f"Ticker list updated to {len(self.current_tickers)} tickers.", 5000)
 
+    def handle_scan_click(self):
+        if self.is_scanning:
+            self.stop_scan()
+        else:
+            self.start_scan()
+
+    def on_ticker_source_changed(self, index):
+        source = self.ticker_source_combo.itemText(index)
+        self.manage_tickers_button.setEnabled(source == "Custom List")
+
     def start_scan(self):
-        self.scan_button.setEnabled(False); self.save_csv_button.setEnabled(False); self.search_bar.setEnabled(False); self.search_bar.clear(); self.progress_bar.setValue(0); self.progress_bar.setVisible(True); self.results_table.setRowCount(0)
+        ticker_source = self.ticker_source_combo.currentText()
+
+        # --- Determine Tickers to Scan ---
+        if ticker_source == "Default List":
+            self.current_tickers = screener_engine.get_default_tickers()
+        elif ticker_source == "Custom List":
+            # self.current_tickers is already up-to-date from the dialog
+            pass
+        else: # It's an index
+            if not self.api_key:
+                QMessageBox.critical(self, "API Key Required", f"An FMP API key is required to fetch tickers from the {ticker_source} index.\n\nPlease add one in Settings.")
+                return
+
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            self.statusBar().showMessage(f"Fetching tickers for {ticker_source}...")
+            QApplication.processEvents() # Force UI update
+
+            new_tickers = screener_engine.get_tickers_from_index(ticker_source, self.api_key)
+
+            QApplication.restoreOverrideCursor()
+
+            if new_tickers is None:
+                QMessageBox.critical(self, "Error", f"Failed to fetch ticker list for {ticker_source}.\nThis might be a network issue or an invalid API key.")
+                self.statusBar().showMessage(f"Failed to fetch tickers for {ticker_source}.", 8000)
+                return
+            self.current_tickers = new_tickers
+
+        if not self.current_tickers:
+            QMessageBox.warning(self, "No Tickers", "The selected ticker list is empty.")
+            return
+
+        # --- Start the Scan ---
+        self.is_scanning = True
+        self.scan_button.setText("Stop Scan")
+        self.save_csv_button.setEnabled(False); self.search_bar.setEnabled(False); self.search_bar.clear(); self.progress_bar.setValue(0); self.progress_bar.setVisible(True); self.results_table.setRowCount(0)
         self.search_col_indices = None # Reset cached column indices
         data_source = "FMP" if self.api_key else "yfinance"
-        self.statusBar().showMessage(f"Starting scan for {len(self.current_tickers)} tickers using {data_source}...")
+        self.statusBar().showMessage(f"Starting scan for {len(self.current_tickers)} tickers ({ticker_source}) using {data_source}...")
         self.worker = ScanWorker(self.strategy_combo.currentText().replace(" ", "_"), self.current_tickers, self.api_key)
         self.worker.progress.connect(self.update_progress)
         self.worker.finished.connect(self.scan_finished)
         self.worker.start()
+
+    def stop_scan(self):
+        if self.worker and self.worker.isRunning():
+            self.worker.stop()
+            self.statusBar().showMessage("Stopping scan...")
+            self.scan_button.setEnabled(False) # Prevent multiple clicks
 
     def update_progress(self, progress_data):
         count, total, ticker = progress_data
@@ -499,7 +569,17 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage(f"Scanning ({count}/{total}): {ticker}...")
 
     def scan_finished(self, results):
-        self.progress_bar.setVisible(False); self.scan_button.setEnabled(True)
+        was_stopped = self.worker.is_stopped() if self.worker else False
+        self.is_scanning = False
+        self.scan_button.setText("Start Scan")
+        self.scan_button.setEnabled(True)
+        self.progress_bar.setVisible(False)
+        self.worker = None
+
+        if was_stopped:
+            self.statusBar().showMessage("Scan stopped by user.", 10000)
+            return
+
         if not results:
              self.statusBar().showMessage("Scan failed: No results returned.", 10000)
              return

--- a/app/screener_engine.py
+++ b/app/screener_engine.py
@@ -61,7 +61,7 @@ def save_strategy_definitions(strategies):
     with open(STRATEGIES_FILE, 'w') as f:
         json.dump(strategies, f, indent=4)
 
-def get_global_top_tickers():
+def get_default_tickers():
     # This list is a combination of the original tickers and a sample of new tickers from major indices.
     tickers = [
         "0001.HK", "0002.HK", "0003.HK", "0005.HK", "0011.HK", "0012.HK", "0016.HK", "0017.HK", "005380.KS",
@@ -133,6 +133,49 @@ def get_global_top_tickers():
         "ZM", "ZS", "ZTS", "ZURN.SW"
     ]
     return sorted(list(set(tickers)))
+
+def get_tickers_from_index(index_name, api_key):
+    """
+    Fetches the list of tickers for a given index from the FMP API.
+    Returns a list of tickers or None if an error occurs.
+    """
+    if not api_key:
+        logging.error("API key is required to fetch index constituents.")
+        return None
+
+    index_map = {
+        "S&P 500": "sp500-constituent",
+        "Nasdaq 100": "nasdaq-constituent",
+        "Dow Jones": "dowjones-constituent"
+    }
+
+    endpoint = index_map.get(index_name)
+    if not endpoint:
+        logging.error(f"Invalid index name specified: {index_name}")
+        return None
+
+    url = f"https://financialmodelingprep.com/api/v3/{endpoint}?apikey={api_key}"
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Raise an exception for bad status codes
+        data = response.json()
+
+        # The response is a list of dictionaries, each with a 'symbol' key.
+        tickers = [item['symbol'] for item in data]
+        logging.info(f"Successfully fetched {len(tickers)} tickers for {index_name}.")
+        return sorted(list(set(tickers)))
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"API request failed for {index_name}: {e}")
+        return None
+    except json.JSONDecodeError:
+        logging.error(f"Failed to decode JSON response for {index_name}.")
+        return None
+    except KeyError:
+        logging.error(f"Unexpected JSON structure in response for {index_name}.")
+        return None
+
 
 def safe_float(value, default=np.nan):
     try: return float(value) if pd.notna(value) else default
@@ -237,7 +280,7 @@ def calculate_metrics_yfinance(ticker_symbol):
         return metrics
     except Exception as e: return None
 
-def run_complete_screener(strategy, tickers, api_key, progress_callback):
+def run_complete_screener(strategy, tickers, api_key, progress_callback, worker=None):
     all_tickers = tickers; total_tickers = len(all_tickers); results = []; failed_list = []
 
     use_fmp = api_key is not None and len(api_key) > 10
@@ -250,6 +293,16 @@ def run_complete_screener(strategy, tickers, api_key, progress_callback):
             future_to_ticker = {executor.submit(fetch_function, ticker): ticker for ticker in all_tickers}
 
         for i, future in enumerate(as_completed(future_to_ticker)):
+            if worker and worker.is_stopped():
+                # Cancel all pending futures
+                for f in future_to_ticker:
+                    f.cancel()
+                # We need to drain the futures to avoid issues, but with a timeout
+                for f in as_completed(future_to_ticker, timeout=0.5):
+                    pass
+                logging.info("Scan stopped by user.")
+                return None # Indicate that the scan was stopped
+
             ticker = future_to_ticker[future]
             progress_callback.emit((i + 1, total_tickers, ticker))
             try:
@@ -264,6 +317,9 @@ def run_complete_screener(strategy, tickers, api_key, progress_callback):
             except Exception as e:
                 failed_list.append(f"{ticker}: Data request failed ({type(e).__name__}).")
                 logging.warning(f"Ticker {ticker} caused an exception: {e}")
+
+    if worker and worker.is_stopped():
+        return None
 
     if not results:
         summary = { "total_tickers": total_tickers, "initial_count": 0, "failed_count": len(failed_list), "final_count": 0, "failed_list": failed_list }


### PR DESCRIPTION
This commit introduces two major features:

1. Stoppable Scans:
   - Users can now stop a scan that is in progress by clicking the "Stop Scan" button.
   - The backend gracefully terminates the running scan and cancels any pending data requests.

2. Index-Based Ticker Selection:
   - A new dropdown menu allows users to select the source for tickers.
   - In addition to the default and custom lists, users can now choose to scan all constituents of the S&P 500, Nasdaq 100, or Dow Jones indices.
   - This feature requires a Financial Modeling Prep (FMP) API key, and the user is prompted if one is needed but not configured.