### PR TITLE
feat: Add comprehensive ticker fetching and UI selection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from PySide6.QtCore import QThread, Signal, Qt
 from PySide6.QtGui import QAction, QColor, QBrush
 
 import screener_engine
+import ticker_fetcher
 from help_texts import HELP_TEXT_DE, HELP_TEXT_EN
 import copy
 import technical_analyzer
@@ -410,7 +411,10 @@ class MainWindow(QMainWindow):
         # --- Ticker Source Selection ---
         self.ticker_source_label = QLabel("Ticker Source:")
         self.ticker_source_combo = QComboBox()
-        self.ticker_source_combo.addItems(["Default List", "S&P 500", "Nasdaq 100", "Dow Jones", "Custom List"])
+        self.ticker_source_combo.addItems([
+            "Default List", "DAX", "MDAX", "SDAX", "TecDAX",
+            "S&P 500", "Nasdaq 100", "Dow Jones", "Custom List"
+        ])
         self.ticker_source_combo.currentIndexChanged.connect(self.on_ticker_source_changed)
         self.manage_tickers_button = QPushButton("Manage Custom List")
         self.manage_tickers_button.setEnabled(False)
@@ -514,34 +518,47 @@ class MainWindow(QMainWindow):
 
     def start_scan(self):
         ticker_source = self.ticker_source_combo.currentText()
+        self.current_tickers = []
+        new_tickers = None
 
-        # --- Determine Tickers to Scan ---
-        if ticker_source == "Default List":
-            self.current_tickers = screener_engine.get_default_tickers()
-        elif ticker_source == "Custom List":
-            # self.current_tickers is already up-to-date from the dialog
-            pass
-        else: # It's an index
-            if not self.api_key:
-                QMessageBox.critical(self, "API Key Required", f"An FMP API key is required to fetch tickers from the {ticker_source} index.\n\nPlease add one in Settings.")
-                return
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        self.statusBar().showMessage(f"Fetching tickers for {ticker_source}...")
+        QApplication.processEvents()
 
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            self.statusBar().showMessage(f"Fetching tickers for {ticker_source}...")
-            QApplication.processEvents() # Force UI update
+        try:
+            if ticker_source == "Default List":
+                new_tickers = screener_engine.get_default_tickers()
+            elif ticker_source == "Custom List":
+                # No fetch needed, current_tickers is managed by dialog
+                new_tickers = self.current_tickers
+            elif ticker_source == "DAX":
+                new_tickers = ticker_fetcher.get_dax_tickers()
+            elif ticker_source == "MDAX":
+                new_tickers = ticker_fetcher.get_mdax_tickers()
+            elif ticker_source == "SDAX":
+                new_tickers = ticker_fetcher.get_sdax_tickers()
+            elif ticker_source == "TecDAX":
+                new_tickers = ticker_fetcher.get_tecdax_tickers()
+            else: # US Indices that require an API key
+                if not self.api_key:
+                    QMessageBox.critical(self, "API Key Required", f"An FMP API key is required to fetch tickers from the {ticker_source} index.\n\nPlease add one in Settings.")
+                    new_tickers = None # Ensure we don't proceed
+                else:
+                    new_tickers = screener_engine.get_tickers_from_index(ticker_source, self.api_key)
 
-            new_tickers = screener_engine.get_tickers_from_index(ticker_source, self.api_key)
+            if new_tickers is None and ticker_source not in ["Custom List"]:
+                 QMessageBox.critical(self, "Error", f"Failed to fetch ticker list for {ticker_source}.\nThis might be a network issue or an invalid API key.")
+                 self.statusBar().showMessage(f"Failed to fetch tickers for {ticker_source}.", 8000)
+            else:
+                self.current_tickers = new_tickers
 
+        finally:
             QApplication.restoreOverrideCursor()
-
-            if new_tickers is None:
-                QMessageBox.critical(self, "Error", f"Failed to fetch ticker list for {ticker_source}.\nThis might be a network issue or an invalid API key.")
-                self.statusBar().showMessage(f"Failed to fetch tickers for {ticker_source}.", 8000)
-                return
-            self.current_tickers = new_tickers
+            self.statusBar().clearMessage()
 
         if not self.current_tickers:
-            QMessageBox.warning(self, "No Tickers", "The selected ticker list is empty.")
+            if ticker_source != "Custom List": # Avoid warning for an empty custom list on startup
+                QMessageBox.warning(self, "No Tickers", f"The ticker list for '{ticker_source}' is empty or could not be loaded.")
             return
 
         # --- Start the Scan ---
@@ -752,4 +769,6 @@ class MainWindow(QMainWindow):
             self.strategy_combo.setToolTip("<br>".join(tooltip_parts))
 
 if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     app = QApplication(sys.argv); app.setDesktopFileName("io.github.BioVisualizer.Rectifex"); window = MainWindow(); window.show(); sys.exit(app.exec())

--- a/app/screener_engine.py
+++ b/app/screener_engine.py
@@ -1,14 +1,14 @@
-import yfinance as yf
+import requests
 import pandas as pd
 import numpy as np
 import logging
-import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import configparser
 from pathlib import Path
 import os
 import time
 import json
+import ticker_fetcher
 
 # --- Global Configuration ---
 APPROX_RATES = {
@@ -61,78 +61,13 @@ def save_strategy_definitions(strategies):
     with open(STRATEGIES_FILE, 'w') as f:
         json.dump(strategies, f, indent=4)
 
-def get_default_tickers():
-    # This list is a combination of the original tickers and a sample of new tickers from major indices.
-    tickers = [
-        "0001.HK", "0002.HK", "0003.HK", "0005.HK", "0011.HK", "0012.HK", "0016.HK", "0017.HK", "005380.KS",
-        "005490.KS", "005930.KS", "0066.HK", "00660.KS", "0267.HK", "035420.KS", "0386.HK", "0388.HK",
-        "051910.KS", "068270.KS", "0700.HK", "0857.HK", "0883.HK", "0939.HK", "0941.HK", "1044.HK", "1299.HK",
-        "1721.T", "1801.T", "1802.T", "1803.T", "1808.T", "1812.T", "1925.T", "1928.T", "1963.T", "1COV.DE",
-        "207940.KS", "2303.TW", "2308.TW", "2317.TW", "2318.HK", "2330.TW", "2382.TW", "2412.TW", "2454.TW",
-        "2628.HK", "2881.TW", "2882.TW", "3405.T", "3407.T", "3988.HK", "4004.T", "4005.T", "4021.T", "4042.T",
-        "4043.T", "4061.T", "4063.T", "4183.T", "4188.T", "4208.T", "4452.T", "4631.T", "4901.T", "4911.T",
-        "5831.T", "6752.T", "6758.T", "6988.T", "7186.T", "7201.T", "7202.T", "7203.T", "7205.T", "7211.T",
-        "7261.T", "7267.T", "7269.T", "7270.T", "7272.T", "7974.T", "8031.T", "8058.T", "8304.T", "8306.T",
-        "8308.T", "8309.T", "8316.T", "8331.T", "8354.T", "8411.T", "9202.T", "9432.T", "9433.T", "9434.T",
-        "9613.T", "9983.T", "9984.T", "9988.HK", "A", "AAL", "AAL.L", "AAP", "AAPL", "ABBN.SW", "ABBV", "ABEV",
-        "ABI.BR", "ABNB", "ABT", "AC.PA", "ACA.PA", "ACN", "AD.AS", "ADANIENT.NS", "ADBE", "ADI", "ADP",
-        "ADS.DE", "ADYEN.AS", "AENA.MC", "AEP", "AFRM", "AGN.AS", "AI.PA", "AIG", "AIR.DE", "AIR.PA", "AKAM",
-        "ALL.AX", "ALO.PA", "ALV.DE", "AMAT", "AMC.AX", "AMD", "AMGN", "AMP.AX", "AMT", "AMZN", "ANSS",
-        "ANTO.L", "ANZ.AX", "AON", "APA", "APA.AX", "APD", "APH", "APT.AX", "ARW", "ASIANPAINT.NS", "ASML.AS",
-        "ASRNL.AS", "ASX.AX", "ATD.TO", "ATO.PA", "AV.L", "AVB", "AVGO", "AVY", "AWK", "AXISBANK.NS", "AXP",
-        "AZN", "AZN.L", "BA", "BA.L", "BABA", "BAC", "BAFN.SW", "BAJFINANCE.NS", "BAS.DE", "BATS.L", "BAX",
-        "BAYN.DE", "BBDC4.SA", "BBY", "BCE", "BDX", "BEI.DE", "BEN", "BHARTIARTL.NS", "BHP.AX", "BILL", "BK",
-        "BKNG", "BLK", "BMO", "BMW.DE", "BMY", "BNP.PA", "BNS", "BNS.TO", "BP", "BP.L", "BRK-A", "BRK-B",
-        "BT-A.L", "BXB.AX", "C", "CA.PA", "CABK.MC", "CAP.PA", "CARR", "CAT", "CBA.AX", "CCH.L", "CDNS", "CE",
-        "CFR.SW", "CHTR", "CI", "CL", "CLNX.MC", "CM.TO", "CME", "CMG", "CMI", "CMCSA", "CNP", "CNQ", "CNR.TO",
-        "COF", "COIN", "COL.AX", "CON.DE", "COO", "COP", "COST", "CP.TO", "CPG.L", "CPRT", "CPT", "CRM", "CRWD",
-        "CS.PA", "CSCO", "CSGN.SW", "CSL.AX", "CSU.TO", "CSX", "CTAS", "CTSH", "CVS", "CVX", "D", "DAI.DE",
-        "DAL", "DASH", "DB1.DE", "DBK.DE", "DD", "DDOG", "DE", "DFS", "DG", "DGX", "DHER.DE", "DHI", "DHR",
-        "DHL.DE", "DIS", "DLR", "DLTR", "DOV", "DOW", "DPW.DE", "DSM.AS", "DTE.DE", "DTG.DE", "DUK", "DVN",
-        "DXCM", "EA", "EBAY", "EIX", "EL", "EMN", "EN.PA", "ENB", "ENB.TO", "ENEL.MI", "ENG.MC", "ENGI.PA",
-        "ENI.MI", "ENPH", "ENR.DE", "EOAN.DE", "EOG", "EQNR.OL", "EQR", "ERF.PA", "ES", "ESS", "ETN", "ETSY",
-        "EW", "EXC", "EXPD", "EXPE", "F", "FAST", "FDX", "FE", "FER.MC", "FFIV", "FIS", "FISV", "FITB", "FLG.MC",
-        "FLTR.L", "FME.DE", "FMG.AX", "FRE.DE", "FRES.L", "FSLR", "GD", "GE", "GGB", "GGBR4.SA", "GIB-A.TO",
-        "GILD", "GIS", "GIVN.SW", "GLE.PA", "GLW", "GM", "GMG.AX", "GOOGL", "GPN", "GRF.MC", "GRMN", "GS",
-        "GSK", "GSK.L", "GWW", "HAL", "HAS", "HBAN", "HCA", "HCLTECH.NS", "HD", "HDFCBANK.NS", "HEI.DE",
-        "HEIA.AS", "HEN3.DE", "HES", "HIK.L", "HINDUNILVR.NS", "HLT", "HNR1.DE", "HOLN.SW", "HON", "HRL",
-        "HSBC", "HSBC.L", "HST", "HUM", "IAG.AX", "IAG.L", "IBE.MC", "IBM", "ICE", "ICICIBANK.NS", "IDR.MC",
-        "IDXX", "IEX", "IFX.DE", "IHG.L", "III.L", "ILMN", "IMCD.AS", "IMO.TO", "IMP.L", "INF.L", "INFY.NS",
-        "INGA.AS", "INTC", "INTU", "IP", "IPG", "IQV", "IR", "IRM", "ISRG", "ISP.MI", "ITRK.L", "ITUB",
-        "ITUB4.SA", "ITW", "ITX.MC", "IVZ", "JCI", "JD.L", "JNJ", "JPM", "K", "KER.PA", "KEY", "KHC", "KIM",
-        "KMB", "KMI", "KO", "KOTAKBANK.NS", "KPN.AS", "KR", "L", "L.TO", "LAND.L", "LEG", "LGEN.L", "LH",
-        "LHX", "LIN", "LIN.DE", "LLC.AX", "LLOY.L", "LLY", "LMT", "LNT", "LOGN.SW", "LOW", "LR.PA", "LT.NS",
-        "LUV", "LVMH.PA", "LYB", "LYV", "M&M.NS", "MA", "MAP.MC", "MAR", "MARUTI.NS", "MAS", "MB.MI", "MBG.DE",
-        "MC.PA", "MCD", "MCHP", "MCK", "MCO", "MDB", "MDLZ", "MDT", "MEL.MC", "META", "MFC", "MG.TO", "ML.PA",
-        "MMC", "MMM", "MNG.L", "MNST", "MO", "MOS", "MPC", "MQG.AX", "MRK", "MRK.DE", "MRL.MC", "MRO",
-        "MRO.L", "MS", "MSCI", "MSFT", "MSI", "MTB", "MTD", "MTX.DE", "MU", "MUV2.DE", "NAB.AX", "NCLH",
-        "NCM.AX", "NDAQ", "NEE", "NEM", "NESN.SW", "NET", "NFLX", "NG.L", "NI", "NKE", "NN.AS", "NOC",
-        "NOVN.SW", "NOVO-B.CO", "NOW", "NRG", "NSC", "NST.AX", "NTAP", "NTGY.MC", "NTR.TO", "NTRS", "NVR",
-        "NWG.L", "NWL", "NWSA", "O", "OCADO.L", "OKE", "OKTA", "OR.PA", "ORA.PA", "ORCL", "OXY", "P911.DE",
-        "PAH3.DE", "PANW", "PART.SW", "PATH", "PAYC", "PAYX", "PBR", "PCAR", "PDD", "PEG", "PEP", "PETR4.SA",
-        "PFE", "PFG", "PG", "PGR", "PH", "PHIA.AS", "PHM", "PHNX.L", "PINS", "PKG", "PLD", "PLTR", "PM",
-        "PNC", "PNR", "PNW", "POOL", "PPG", "PPL", "PRU", "PRU.L", "PRX.AS", "PSA", "PSN.L", "PSON.L", "PSX",
-        "PUB.PA", "PUM.DE", "PVH", "PWR", "PXD", "PYPL", "QAN.AX", "QBE.AX", "QCOM", "QIA.DE", "QRVO",
-        "RACE.MI", "RAND.AS", "RBLX", "RCL", "REG", "REGN", "RELIANCE.NS", "REN.AS", "REP.MC", "RF", "RHM.DE",
-        "RHI", "RI.PA", "RIO.AX", "RIO.L", "RL", "RMD", "RNO.PA", "ROG.SW", "ROK", "ROKU", "ROL", "ROP",
-        "ROST", "RR.L", "RSG", "RTO.L", "RTX", "RWE.DE", "RY", "RY.TO", "SAF.PA", "SAN.MC", "SAN.PA", "SAP",
-        "SAP.DE", "SBAC", "SBIN.NS", "SBRY.L", "SBUX", "SCCO", "SCG.AX", "SCHW", "SCMN.SW", "SEDG", "SEE",
-        "SGE.L", "SGO.PA", "SGP.AX", "SGSN.SW", "SHEL", "SHEL.L", "SHELL.AS", "SHL.DE", "SHOP.TO", "SHW",
-        "SIE.DE", "SJM", "SLB", "SLF.TO", "SLHN.SW", "SMIN.L", "SMT.L", "SNA", "SN.L", "SNOW", "SO", "SOFI",
-        "SPOT", "SPG", "SPGI", "SQ", "SRE", "SREN.SW", "SRT3.DE", "SSE.L", "STAN.L", "STE", "STLA", "STM.MI",
-        "STO.AX", "STT", "STX", "STZ", "SU", "SU.PA", "SU.TO", "SUN.AX", "SUNPHARMA.NS", "SWK", "SWKS",
-        "SY1.DE", "SYK", "T", "T.TO", "TAP", "TATASTEEL.NS", "TCL.AX", "TCS.NS", "TD", "TD.TO", "TDG", "TE.PA",
-        "TEF.MC", "TEL", "TEN.MI", "TFC", "TFX", "TGT", "TITAN.NS", "TJX", "TLS.AX", "TMO", "TMUS", "TRMB",
-        "TRP", "TRP.TO", "TRV", "TSCO", "TSCO.L", "TSLA", "TSN", "TT", "TTD", "TTE", "TTE.PA", "TWLO", "TXT",
-        "U", "UAL", "UBSG.SW", "UCG.MI", "UDR", "UGI", "UHR.SW", "UL", "ULVR.L", "UMG.AS", "UMG.PA", "UMPQ",
-        "UNA.AS", "UNH", "UNP", "UPS", "UPST", "URI", "USB", "V", "VALE", "VALE3.SA", "VFC", "VICI", "VIE.PA",
-        "VIV.PA", "VLO", "VMC", "VNA.DE", "VNO", "VOD.L", "VOLV-B.ST", "VOW3.DE", "VRSK", "VRSN", "VRTX",
-        "VTR", "VZ", "WBA", "WBC.AX", "WBD", "WCN.TO", "WDC", "WDAY", "WDS.AX", "WEC", "WEGE3.SA", "WELL",
-        "WES.AX", "WFC", "WHR", "WIPRO.NS", "WKL.AS", "WM", "WMB", "WMT", "WOW.AX", "WPM", "WRB", "WRK",
-        "WST", "WTB.L", "WY", "WYNN", "XEL", "XOM", "XRX", "XYL", "YUM", "ZAL.DE", "ZBH", "ZBRA", "ZION",
-        "ZM", "ZS", "ZTS", "ZURN.SW"
-    ]
-    return sorted(list(set(tickers)))
+def get_default_tickers(force_refresh=False):
+    """
+    Returns a comprehensive list of tickers from multiple major indices,
+    fetched and cached by the ticker_fetcher module.
+    """
+    logging.info("Using ticker_fetcher to get default tickers.")
+    return ticker_fetcher.get_all_tickers(force_refresh=force_refresh)
 
 def get_tickers_from_index(index_name, api_key):
     """

--- a/app/test_screener_engine.py
+++ b/app/test_screener_engine.py
@@ -1,0 +1,29 @@
+import unittest
+import sys
+sys.path.append('.')
+from app import screener_engine
+
+class TestScreenerEngine(unittest.TestCase):
+
+    def test_get_default_tickers(self):
+        """
+        Tests that get_default_tickers returns a list of tickers
+        and that it includes the specifically requested stocks.
+        """
+        # Force a refresh to ensure we are not using a stale cache
+        tickers = screener_engine.get_default_tickers(force_refresh=True)
+
+        # Check that it returns a list
+        self.assertIsInstance(tickers, list)
+
+        # Check that the list is not empty
+        self.assertGreater(len(tickers), 0)
+
+        # Check for the presence of the requested stocks
+        required_stocks = ["NVDA", "PLTR", "GOOGL", "GOOG", "MSFT", "SRT3.DE", "SRT.DE", "HYQ.DE"]
+        ticker_set = set(tickers)
+        for stock in required_stocks:
+            self.assertIn(stock, ticker_set)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_ui.py
+++ b/app/test_ui.py
@@ -1,0 +1,58 @@
+import sys
+import logging
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QTimer
+from main import MainWindow
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def run_test():
+    app = QApplication.instance()
+    if not app:
+        app = QApplication(sys.argv)
+
+    window = MainWindow()
+    window.show()
+
+    logging.info("Starting UI test.")
+
+    def select_dax_and_scan():
+        logging.info("Selecting DAX from dropdown.")
+        dax_index = window.ticker_source_combo.findText("DAX")
+        if dax_index == -1:
+            logging.error("DAX not found in dropdown!")
+            app.quit()
+            return
+
+        window.ticker_source_combo.setCurrentIndex(dax_index)
+
+        logging.info("Clicking scan button.")
+        window.scan_button.click()
+
+        # Give the scan some time to start
+        QTimer.singleShot(2000, check_scan_finished)
+
+    def check_scan_finished():
+        if window.is_scanning:
+            logging.info("Scan is running, checking again in 1 second.")
+            QTimer.singleShot(1000, check_scan_finished)
+        else:
+            logging.info("Scan finished.")
+            verify_results()
+            app.quit()
+
+    def verify_results():
+        row_count = window.results_table.rowCount()
+        logging.info(f"Found {row_count} rows in the results table.")
+        if row_count > 0:
+            logging.info("Test PASSED: Table was populated.")
+        else:
+            logging.error("Test FAILED: Table is empty.")
+
+    # Start the test after the event loop has started
+    QTimer.singleShot(100, select_dax_and_scan)
+
+    sys.exit(app.exec())
+
+if __name__ == "__main__":
+    run_test()

--- a/app/ticker_fetcher.py
+++ b/app/ticker_fetcher.py
@@ -1,0 +1,202 @@
+import requests
+import pandas as pd
+import json
+from pathlib import Path
+import datetime
+import logging
+import io
+import time
+
+# --- Configuration ---
+CACHE_FILE = Path.home() / ".config" / "rectifex" / "tickers.json"
+CACHE_DURATION_DAYS = 7
+
+# Wikipedia URLs
+URL_DAX = "https://en.wikipedia.org/wiki/DAX"
+URL_MDAX = "https://en.wikipedia.org/wiki/MDAX"
+URL_TECDAX_DE = "https://de.wikipedia.org/wiki/TecDAX"
+URL_SDAX_DE = "https://de.wikipedia.org/wiki/SDAX"
+URL_NASDAQ100 = "https://en.wikipedia.org/wiki/Nasdaq-100"
+URL_SP500 = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+
+# --- Global Session ---
+session = requests.Session()
+session.headers.update({'User-Agent': 'RectifexStockScreener/1.0'})
+
+
+def _fetch_html(url):
+    """Fetches HTML content from a URL."""
+    try:
+        response = session.get(url)
+        response.raise_for_status()
+        return response.text
+    except requests.RequestException as e:
+        logging.error(f"Failed to fetch HTML from {url}: {e}")
+        return None
+
+def get_sp500_tickers():
+    """Fetches S&P 500 tickers from Wikipedia."""
+    html = _fetch_html(URL_SP500)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        sp500_table = tables[0]
+        return sp500_table['Symbol'].str.replace('.', '-', regex=False).tolist()
+    except Exception as e:
+        logging.error(f"Could not parse S&P 500 table: {e}")
+        return []
+
+def get_nasdaq100_tickers():
+    """Fetches Nasdaq 100 tickers from Wikipedia."""
+    html = _fetch_html(URL_NASDAQ100)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        nasdaq_table = tables[4]
+        return nasdaq_table['Ticker'].tolist()
+    except Exception as e:
+        logging.error(f"Could not parse Nasdaq 100 table: {e}")
+        return []
+
+def get_dax_tickers():
+    """Fetches DAX tickers from Wikipedia."""
+    html = _fetch_html(URL_DAX)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        dax_table = tables[4]
+        return dax_table['Ticker'].tolist()
+    except Exception as e:
+        logging.error(f"Could not parse DAX table: {e}")
+        return []
+
+def get_mdax_tickers():
+    """Fetches MDAX tickers from Wikipedia."""
+    html = _fetch_html(URL_MDAX)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        mdax_table = tables[2]
+        tickers = mdax_table['Symbol'].dropna().tolist()
+        processed_tickers = []
+        for ticker in tickers:
+            if isinstance(ticker, str):
+                if not any(ticker.endswith(suffix) for suffix in ['.DE', '.LU', '.PA', '.AS']):
+                    processed_tickers.append(f"{ticker}.DE")
+                else:
+                    processed_tickers.append(ticker)
+        return processed_tickers
+    except Exception as e:
+        logging.error(f"Could not parse MDAX table: {e}")
+        return []
+
+def get_tecdax_tickers():
+    """Fetches TecDAX tickers by looking up company names."""
+    companies = get_companies_from_german_wiki(URL_TECDAX_DE)
+    tickers = set()
+    for company in companies:
+        ticker = _search_ticker_yahoo(company)
+        if ticker:
+            tickers.add(ticker)
+    return sorted(list(tickers))
+
+def get_sdax_tickers():
+    """Fetches SDAX tickers by looking up company names."""
+    companies = get_companies_from_german_wiki(URL_SDAX_DE)
+    tickers = set()
+    for company in companies:
+        ticker = _search_ticker_yahoo(company)
+        if ticker:
+            tickers.add(ticker)
+    return sorted(list(tickers))
+
+
+def get_companies_from_german_wiki(url):
+    """Fetches company names from a German Wikipedia index page."""
+    html = _fetch_html(url)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        for table in tables:
+            if 'Name' in table.columns and 'Branche' in table.columns:
+                return table['Name'].str.replace(r'\[.*?\]', '', regex=True).str.strip().tolist()
+        logging.error(f"Could not find a valid company table in {url}")
+        return []
+    except Exception as e:
+        logging.error(f"Could not parse table from {url}: {e}")
+        return []
+
+def _search_ticker_yahoo(company_name):
+    """Searches Yahoo Finance for a ticker symbol for a given company name."""
+    search_url = f"https://query1.finance.yahoo.com/v1/finance/search"
+    params = {'q': company_name, 'quotesCount': 1, 'newsCount': 0}
+    try:
+        time.sleep(0.5)
+        response = session.get(search_url, params=params)
+        response.raise_for_status()
+        data = response.json()
+        if data.get('quotes'):
+            ticker = data['quotes'][0]['symbol']
+            logging.info(f"Found ticker '{ticker}' for company '{company_name}'")
+            return ticker
+        else:
+            logging.warning(f"No ticker found for company '{company_name}' on Yahoo Finance.")
+            return None
+    except requests.RequestException as e:
+        logging.error(f"Yahoo Finance search failed for '{company_name}': {e}")
+        return None
+    except (json.JSONDecodeError, KeyError) as e:
+        logging.error(f"Could not parse Yahoo Finance response for '{company_name}': {e}")
+        return None
+
+
+def get_all_tickers(force_refresh=False):
+    """
+    Aggregates tickers from all sources, using a cache file.
+    """
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    if not force_refresh and CACHE_FILE.exists():
+        try:
+            with open(CACHE_FILE, 'r') as f:
+                data = json.load(f)
+                cache_date = datetime.datetime.fromisoformat(data['date'])
+                if datetime.datetime.now() - cache_date < datetime.timedelta(days=CACHE_DURATION_DAYS):
+                    logging.info("Loading tickers from cache.")
+                    return data['tickers']
+        except (json.JSONDecodeError, KeyError):
+             logging.warning("Cache file is invalid. Fetching fresh data.")
+
+
+    logging.info("Fetching fresh ticker data.")
+    all_tickers = set()
+
+    all_tickers.update(get_sp500_tickers())
+    all_tickers.update(get_nasdaq100_tickers())
+    all_tickers.update(get_dax_tickers())
+    all_tickers.update(get_mdax_tickers())
+    all_tickers.update(get_tecdax_tickers())
+    all_tickers.update(get_sdax_tickers())
+
+    supplementary_tickers = ["NVDA", "PLTR", "GOOGL", "GOOG", "MSFT", "SRT3.DE", "SRT.DE", "HYQ.DE"]
+    all_tickers.update(supplementary_tickers)
+
+    sorted_tickers = sorted(list(filter(None, all_tickers)))
+
+    logging.info(f"Saving {len(sorted_tickers)} tickers to cache.")
+    with open(CACHE_FILE, 'w') as f:
+        json.dump({
+            'date': datetime.datetime.now().isoformat(),
+            'tickers': sorted_tickers
+        }, f, indent=4)
+
+    return sorted_tickers
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    # tickers = get_all_tickers(force_refresh=True)
+    # print(f"\n---> Found {len(tickers)} unique tickers in total. <---")
+    print("DAX:", get_dax_tickers())
+    print("MDAX:", get_mdax_tickers())
+    print("TecDAX:", get_tecdax_tickers())
+    print("SDAX:", get_sdax_tickers())


### PR DESCRIPTION
This commit introduces a major enhancement to the ticker data source for the application.

- A new `ticker_fetcher.py` module has been created to dynamically fetch constituents for major German and US indices (DAX, MDAX, SDAX, TecDAX, S&P 500, NASDAQ 100) from online sources.
- The module includes a caching mechanism to store the fetched tickers for 7 days, providing a form of automated periodic updates as requested.
- The hardcoded default ticker list in `screener_engine.py` has been replaced with a call to the new `ticker_fetcher`, which aggregates all fetched indices and a supplementary list of user-requested stocks (NVDA, HYQ, etc.).
- The user interface in `main.py` has been updated to include dropdown options for the new German indices, allowing users to screen them individually.
- The application now starts with a comprehensive, up-to-date list of tickers by default.
- Added unit tests to verify the new ticker fetching logic.