### PR TITLE
feat: Add comprehensive ticker fetching and UI selection

### DIFF
--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -28,7 +28,7 @@ modules:
   - name: stockscreener
     buildsystem: simple
     build-commands:
-      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py technical_analyzer.py
+      - install -D -t /app/bin/ main.py screener_engine.py help_texts.py technical_analyzer.py ticker_fetcher.py
       - install -D -t /app/share/licenses/io.github.BioVisualizer.Rectifex/ LICENSE
       - install -D -m 755 start.sh /app/bin/start.sh
       - install -D -t /app/share/applications/ share/applications/io.github.BioVisualizer.Rectifex.desktop


### PR DESCRIPTION
This commit introduces a major enhancement to the ticker data source for the application.

- A new `ticker_fetcher.py` module has been created to dynamically fetch constituents for major German and US indices (DAX, MDAX, SDAX, TecDAX, S&P 500, NASDAQ 100) from online sources.
- The module includes a caching mechanism to store the fetched tickers for 7 days, providing a form of automated periodic updates as requested.
- The hardcoded default ticker list in `screener_engine.py` has been replaced with a call to the new `ticker_fetcher`, which aggregates all fetched indices and a supplementary list of user-requested stocks (NVDA, HYQ, etc.).
- The user interface in `main.py` has been updated to include dropdown options for the new German indices, allowing users to screen them individually.
- The application now starts with a comprehensive, up-to-date list of tickers by default.
- Added unit tests to verify the new ticker fetching logic.

fix: Add ticker_fetcher.py to Flatpak build manifest to resolve ModuleNotFoundError.