### PR TITLE
Feat: Expand default ticker list to be more global

### DIFF
--- a/app/ticker_fetcher.py
+++ b/app/ticker_fetcher.py
@@ -11,16 +11,22 @@ import time
 CACHE_FILE = Path.home() / ".config" / "rectifex" / "tickers.json"
 CACHE_DURATION_DAYS = 7
 
-# Wikipedia URLs
+# Wikipedia URLs for various global indices
+URL_SP500 = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+URL_NASDAQ100 = "https://en.wikipedia.org/wiki/Nasdaq-100"
 URL_DAX = "https://en.wikipedia.org/wiki/DAX"
 URL_MDAX = "https://en.wikipedia.org/wiki/MDAX"
 URL_TECDAX_DE = "https://de.wikipedia.org/wiki/TecDAX"
 URL_SDAX_DE = "https://de.wikipedia.org/wiki/SDAX"
-URL_SP500 = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+URL_FTSE100 = "https://en.wikipedia.org/wiki/FTSE_100_Index"
+URL_CAC40 = "https://en.wikipedia.org/wiki/CAC_40"
+URL_NIKKEI225 = "https://en.wikipedia.org/wiki/Nikkei_225"
+URL_TSX_COMPOSITE = "https://en.wikipedia.org/wiki/List_of_companies_in_the_S%26P/TSX_Composite_Index"
+
 
 # --- Global Session ---
 session = requests.Session()
-session.headers.update({'User-Agent': 'RectifexStockScreener/1.0'})
+session.headers.update({'User-Agent': 'RectifexStockScreener/1.2'})
 
 
 def _fetch_html(url):
@@ -33,26 +39,35 @@ def _fetch_html(url):
         logging.error(f"Failed to fetch HTML from {url}: {e}")
         return None
 
+# --- Ticker Scraping Functions for Each Index ---
+
 def get_sp500_tickers():
-    """Fetches S&P 500 tickers from Wikipedia."""
     html = _fetch_html(URL_SP500)
     if not html: return []
     try:
         tables = pd.read_html(io.StringIO(html))
         sp500_table = tables[0]
-        # The symbol column sometimes has dots, which yfinance expects as dashes
         return sp500_table['Symbol'].str.replace('.', '-', regex=False).tolist()
     except Exception as e:
         logging.error(f"Could not parse S&P 500 table: {e}")
         return []
 
+def get_nasdaq100_tickers():
+    html = _fetch_html(URL_NASDAQ100)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        nasdaq_table = tables[4]
+        return nasdaq_table['Ticker'].tolist()
+    except Exception as e:
+        logging.error(f"Could not parse Nasdaq 100 table: {e}")
+        return []
+
 def get_dax_tickers():
-    """Fetches DAX tickers from Wikipedia."""
     html = _fetch_html(URL_DAX)
     if not html: return []
     try:
         tables = pd.read_html(io.StringIO(html))
-        # This index can change, it's a risk of this method
         dax_table = tables[4]
         return dax_table['Ticker'].tolist()
     except Exception as e:
@@ -60,84 +75,99 @@ def get_dax_tickers():
         return []
 
 def get_mdax_tickers():
-    """Fetches MDAX tickers from Wikipedia."""
     html = _fetch_html(URL_MDAX)
     if not html: return []
     try:
         tables = pd.read_html(io.StringIO(html))
         mdax_table = tables[2]
         tickers = mdax_table['Symbol'].dropna().tolist()
-        # Add .DE suffix if missing, as is common for German listings
-        processed_tickers = []
-        for ticker in tickers:
-            if isinstance(ticker, str):
-                if not any(ticker.endswith(suffix) for suffix in ['.DE', '.LU', '.PA', '.AS']):
-                    processed_tickers.append(f"{ticker}.DE")
-                else:
-                    processed_tickers.append(ticker)
+        processed_tickers = [f"{t}.DE" if not any(t.endswith(s) for s in ['.DE','.LU','.PA','.AS']) else t for t in tickers if isinstance(t, str)]
         return processed_tickers
     except Exception as e:
         logging.error(f"Could not parse MDAX table: {e}")
         return []
 
-def get_companies_from_german_wiki(url):
-    """Helper to get company names from German Wikipedia index pages."""
-    html = _fetch_html(url)
+def get_ftse100_tickers():
+    html = _fetch_html(URL_FTSE100)
     if not html: return []
     try:
         tables = pd.read_html(io.StringIO(html))
-        for table in tables:
-            # Look for a table with these specific columns
-            if 'Name' in table.columns and 'Branche' in table.columns:
-                # Remove citations like [2] from names
-                return table['Name'].str.replace(r'\[.*?\]', '', regex=True).str.strip().tolist()
-        logging.error(f"Could not find a valid company table in {url}")
-        return []
+        ftse_table = tables[3]
+        return ftse_table['Ticker'].tolist()
     except Exception as e:
-        logging.error(f"Could not parse table from {url}: {e}")
+        logging.error(f"Could not parse FTSE 100 table: {e}")
         return []
 
+def get_cac40_tickers():
+    html = _fetch_html(URL_CAC40)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        cac_table = tables[4]
+        return cac_table['Ticker'].tolist()
+    except Exception as e:
+        logging.error(f"Could not parse CAC 40 table: {e}")
+        return []
+
+def get_nikkei225_tickers():
+    html = _fetch_html(URL_NIKKEI225)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        nikkei_table = tables[1]
+        return (nikkei_table['Ticker symbol'].astype(str) + '.T').tolist()
+    except Exception as e:
+        logging.error(f"Could not parse Nikkei 225 table: {e}")
+        return []
+
+def get_tsx_composite_tickers():
+    html = _fetch_html(URL_TSX_COMPOSITE)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        tsx_table = tables[0]
+        return tsx_table['Symbol'].str.replace('.', '-', regex=False).tolist()
+    except Exception as e:
+        logging.error(f"Could not parse S&P/TSX Composite table: {e}")
+        return []
+
+# --- Functions requiring Yahoo Finance search (slower) ---
+
 def _search_ticker_yahoo(company_name):
-    """Searches Yahoo Finance for a ticker symbol for a given company name."""
     search_url = f"https://query1.finance.yahoo.com/v1/finance/search"
     params = {'q': company_name, 'quotesCount': 1, 'newsCount': 0}
     try:
-        # Add a delay to avoid getting rate-limited
         time.sleep(0.5)
         response = session.get(search_url, params=params, timeout=15)
         response.raise_for_status()
         data = response.json()
         if data.get('quotes'):
-            ticker = data['quotes'][0]['symbol']
-            logging.info(f"Found ticker '{ticker}' for company '{company_name}'")
-            return ticker
-        else:
-            logging.warning(f"No ticker found for company '{company_name}' on Yahoo Finance.")
-            return None
-    except (requests.RequestException, json.JSONDecodeError, KeyError) as e:
+            return data['quotes'][0]['symbol']
+    except Exception as e:
         logging.error(f"Yahoo Finance search failed for '{company_name}': {e}")
-        return None
+    return None
+
+def get_companies_from_german_wiki(url):
+    html = _fetch_html(url)
+    if not html: return []
+    try:
+        tables = pd.read_html(io.StringIO(html))
+        for table in tables:
+            if 'Name' in table.columns and 'Branche' in table.columns:
+                return table['Name'].str.replace(r'\[.*?\]', '', regex=True).str.strip().tolist()
+    except Exception as e:
+        logging.error(f"Could not parse table from {url}: {e}")
+    return []
 
 def get_tecdax_tickers():
-    """Fetches TecDAX tickers by looking up company names."""
     companies = get_companies_from_german_wiki(URL_TECDAX_DE)
-    tickers = set()
-    for company in companies:
-        ticker = _search_ticker_yahoo(company)
-        if ticker:
-            tickers.add(ticker)
-    return sorted(list(tickers))
+    return [t for t in (_search_ticker_yahoo(c) for c in companies) if t]
 
 def get_sdax_tickers():
-    """Fetches SDAX tickers by looking up company names."""
     companies = get_companies_from_german_wiki(URL_SDAX_DE)
-    tickers = set()
-    for company in companies:
-        ticker = _search_ticker_yahoo(company)
-        if ticker:
-            tickers.add(ticker)
-    return sorted(list(tickers))
+    return [t for t in (_search_ticker_yahoo(c) for c in companies) if t]
 
+# --- Main Aggregator Function ---
 
 def get_all_tickers(force_refresh=False):
     """
@@ -150,33 +180,31 @@ def get_all_tickers(force_refresh=False):
         try:
             with open(CACHE_FILE, 'r') as f:
                 data = json.load(f)
-                cache_date = datetime.datetime.fromisoformat(data['date'])
-                if datetime.datetime.now() - cache_date < datetime.timedelta(days=CACHE_DURATION_DAYS):
+                if datetime.datetime.now() - datetime.datetime.fromisoformat(data['date']) < datetime.timedelta(days=CACHE_DURATION_DAYS):
                     logging.info("Loading tickers from cache.")
                     return data['tickers']
         except (json.JSONDecodeError, KeyError, ValueError):
-             logging.warning("Ticker cache file is invalid or corrupt. Fetching fresh data.")
+             logging.warning("Ticker cache file is invalid. Fetching fresh data.")
 
-    logging.info("Fetching fresh ticker data from Wikipedia and Yahoo Finance.")
+    logging.info("Fetching fresh global ticker data from Wikipedia and Yahoo Finance.")
     all_tickers = set()
 
+    # Add tickers from all implemented scrapers
     all_tickers.update(get_sp500_tickers())
+    all_tickers.update(get_nasdaq100_tickers())
+    all_tickers.update(get_ftse100_tickers())
+    all_tickers.update(get_cac40_tickers())
+    all_tickers.update(get_nikkei225_tickers())
+    all_tickers.update(get_tsx_composite_tickers())
     all_tickers.update(get_dax_tickers())
     all_tickers.update(get_mdax_tickers())
     all_tickers.update(get_tecdax_tickers())
     all_tickers.update(get_sdax_tickers())
 
-    # Add back the small, static list of important tickers
-    supplementary_tickers = ["NVDA", "PLTR", "GOOGL", "GOOG", "MSFT", "SRT3.DE", "SRT.DE", "HYQ.DE"]
-    all_tickers.update(supplementary_tickers)
-
     sorted_tickers = sorted(list(filter(None, all_tickers)))
 
-    logging.info(f"Saving {len(sorted_tickers)} tickers to cache.")
+    logging.info(f"Saving {len(sorted_tickers)} global tickers to cache.")
     with open(CACHE_FILE, 'w') as f:
-        json.dump({
-            'date': datetime.datetime.now().isoformat(),
-            'tickers': sorted_tickers
-        }, f, indent=4)
+        json.dump({'date': datetime.datetime.now().isoformat(), 'tickers': sorted_tickers}, f)
 
     return sorted_tickers


### PR DESCRIPTION
This commit addresses the user's feedback that the default ticker list was too small. The `ticker_fetcher.py` module has been significantly expanded to scrape several major global indices from Wikipedia, providing a much larger and more diverse set of stocks for analysis in the default, key-less mode.

The following indices have been added to the default scraper:
- Nasdaq 100
- FTSE 100 (UK)
- CAC 40 (France)
- Nikkei 225 (Japan)
- S&P/TSX Composite (Canada)

The `get_all_tickers` function has been updated to aggregate all these new sources, resulting in a comprehensive global stock list for the `yfinance` data path.