### PR TITLE
Feat: Replace scrapers with a hardcoded global ticker list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,8 +51,7 @@ class MainWindow(QMainWindow):
         self.ticker_source_label = QLabel("Ticker Source:")
         self.ticker_source_combo = QComboBox()
         self.ticker_source_combo.addItems([
-            "Default List", "DAX", "MDAX", "SDAX", "TecDAX",
-            "S&P 500", "Nasdaq 100", "Dow Jones", "Custom List"
+            "Default Global List", "Custom List"
         ])
         self.ticker_source_combo.currentIndexChanged.connect(self.on_ticker_source_changed)
         self.manage_tickers_button = QPushButton("Manage Custom List")
@@ -157,65 +156,15 @@ class MainWindow(QMainWindow):
 
     def start_scan(self):
         ticker_source = self.ticker_source_combo.currentText()
-        new_tickers = []
 
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        self.statusBar().showMessage(f"Fetching tickers for {ticker_source}...")
-        QApplication.processEvents()
+        if ticker_source == "Default Global List":
+            self.current_tickers = ticker_fetcher.get_default_tickers()
+        elif ticker_source == "Custom List":
+            # self.current_tickers is already updated by the dialog, so no action needed here.
+            pass
 
-        us_indices = ["S&P 500", "Nasdaq 100", "Dow Jones"]
-
-        try:
-            if ticker_source == "Default List":
-                new_tickers = ticker_fetcher.get_all_tickers()
-            elif ticker_source == "Custom List":
-                new_tickers = self.current_tickers
-            elif ticker_source == "DAX":
-                new_tickers = ticker_fetcher.get_dax_tickers()
-            elif ticker_source == "MDAX":
-                new_tickers = ticker_fetcher.get_mdax_tickers()
-            elif ticker_source == "SDAX":
-                new_tickers = ticker_fetcher.get_sdax_tickers()
-            elif ticker_source == "TecDAX":
-                new_tickers = ticker_fetcher.get_tecdax_tickers()
-            elif ticker_source in us_indices:
-                if not self.api_key:
-                    QMessageBox.critical(self, "API Key Required", f"An FMP API key is required to fetch tickers from the {ticker_source} index.\n\nPlease add one in Settings.")
-                    new_tickers = None # Ensure we don't proceed
-                else:
-                    # This is a placeholder for the FMP API call, which is not in ticker_fetcher anymore
-                    # A better implementation would be to have a unified function.
-                    # For now, I'll add a temporary FMP fetcher here.
-                    # TODO: Refactor this into a unified function later.
-                    import requests # Local import for temporary solution
-                    endpoint = ticker_source.lower().replace(" ", "") + "-constituent"
-                    if ticker_source == "Dow Jones": endpoint = "dowjones-constituent"
-                    if ticker_source == "S&P 500": endpoint = "sp500-constituent"
-                    if ticker_source == "Nasdaq 100": endpoint = "nasdaq-constituent"
-
-                    url = f"https://financialmodelingprep.com/api/v3/{endpoint}?apikey={self.api_key}"
-                    try:
-                        resp = requests.get(url, timeout=15)
-                        resp.raise_for_status()
-                        data = resp.json()
-                        new_tickers = [item['symbol'] for item in data]
-                    except Exception as e:
-                        logging.error(f"FMP API call failed: {e}")
-                        new_tickers = None
-
-            if new_tickers is None:
-                 QMessageBox.critical(self, "Error", f"Failed to fetch ticker list for {ticker_source}.\nThis could be a network issue, or an API key may be required for this source.")
-                 self.statusBar().showMessage(f"Failed to fetch tickers for {ticker_source}.", 8000)
-                 new_tickers = []
-
-            self.current_tickers = new_tickers
-
-        finally:
-            QApplication.restoreOverrideCursor()
-            self.statusBar().clearMessage()
-
-        if not self.current_tickers and ticker_source != "Custom List":
-            QMessageBox.warning(self, "No Tickers", f"The ticker list for '{ticker_source}' is empty or could not be loaded.")
+        if not self.current_tickers:
+            QMessageBox.warning(self, "No Tickers", f"The selected ticker list '{ticker_source}' is empty.")
             return
 
         # --- Start the Scan ---

--- a/app/ticker_fetcher.py
+++ b/app/ticker_fetcher.py
@@ -1,210 +1,91 @@
-import requests
-import pandas as pd
-import json
-from pathlib import Path
-import datetime
 import logging
-import io
-import time
 
-# --- Configuration ---
-CACHE_FILE = Path.home() / ".config" / "rectifex" / "tickers.json"
-CACHE_DURATION_DAYS = 7
+# This list is provided by the user to serve as the new default global stock universe.
+# It is comprehensive and removes the need for unreliable web scraping.
+DEFAULT_TICKER_LIST = [
+    "0001.HK", "0002.HK", "0003.HK", "0005.HK", "0011.HK", "0012.HK", "0016.HK", "0017.HK",
+    "005380.KS", "005490.KS", "005930.KS", "0066.HK", "00660.KS", "0267.HK", "035420.KS",
+    "0386.HK", "0388.HK", "051910.KS", "068270.KS", "0700.HK", "0857.HK", "0883.HK", "0939.HK",
+    "0941.HK", "1044.HK", "1299.HK", "1721.T", "1801.T", "1802.T", "1803.T", "1808.T",
+    "1812.T", "1925.T", "1928.T", "1963.T", "1COV.DE", "207940.KS", "2303.TW", "2308.TW",
+    "2317.TW", "2318.HK", "2330.TW", "2382.TW", "2412.TW", "2454.TW", "2628.HK", "2881.TW",
+    "2882.TW", "3405.T", "3407.T", "3988.HK", "4004.T", "4005.T", "4021.T", "4042.T",
+    "4043.T", "4061.T", "4063.T", "4183.T", "4188.T", "4208.T", "4452.T", "4631.T",
+    "4901.T", "4911.T", "5831.T", "6501.T", "6752.T", "6758.T", "6988.T", "7186.T",
+    "7201.T", "7202.T", "7203.T", "7205.T", "7211.T", "7261.T", "7267.T", "7269.T",
+    "7270.T", "7272.T", "7974.T", "8031.T", "8058.T", "8304.T", "8306.T", "8308.T",
+    "8309.T", "8316.T", "8331.T", "8354.T", "8411.T", "9202.T", "9432.T", "9433.T",
+    "9434.T", "9613.T", "9983.T", "9984.T", "9988.HK", "A", "AAL", "AAL.L", "AAP", "AAPL",
+    "ABBN.SW", "ABBV", "ABEV", "ABI.BR", "ABNB", "ABT", "AC.PA", "ACA.PA", "ACN", "AD.AS",
+    "ADANIENT.NS", "ADBE", "ADI", "ADP", "ADS.DE", "ADYEN.AS", "AENA.MC", "AEP", "AFRM",
+    "AGN.AS", "AI.PA", "AIG", "AIR.DE", "AIR.PA", "AKAM", "ALL.AX", "ALO.PA", "ALV.DE",
+    "AMAT", "AMC.AX", "AMD", "AMGN", "AMP.AX", "AMT", "AMZN", "ANSS", "ANTO.L", "ANZ.AX",
+    "AON", "APA", "APA.AX", "APD", "APH", "APT.AX", "ARW", "ASIANPAINT.NS", "ASML", "ASML.AS",
+    "ASRNL.AS", "ASX.AX", "ATD.TO", "ATO.PA", "AV.L", "AVB", "AVGO", "AVY", "AWK",
+    "AXISBANK.NS", "AXP", "AZN", "AZN.L", "BA", "BA.L", "BABA", "BAC", "BAFN.SW",
+    "BAJFINANCE.NS", "BARC.L", "BAS.DE", "BATS.L", "BAX", "BAYN.DE", "BBDC4.SA", "BBY",
+    "BCE", "BDX", "BEI.DE", "BEN", "BHARTIARTL.NS", "BHP.AX", "BILL", "BK", "BKNG", "BLK",
+    "BMO", "BMW.DE", "BMY", "BNP.PA", "BNS", "BNS.TO", "BP", "BP.L", "BRK-A", "BRK-B",
+    "BT-A.L", "BXB.AX", "C", "CA.PA", "CABK.MC", "CAP.PA", "CARR", "CAT", "CBA.AX", "CCH.L",
+    "CDNS", "CE", "CFR.SW", "CHTR", "CI", "CL", "CLNX.MC", "CM.TO", "CMCSA", "CME", "CMG",
+    "CMI", "CNP", "CNQ", "CNR.TO", "COF", "COIN", "COL.AX", "CON.DE", "COO", "COP", "COST",
+    "CP.TO", "CPG.L", "CPRT", "CPT", "CRM", "CRWD", "CS.PA", "CSCO", "CSGN.SW", "CSL.AX",
+    "CSU.TO", "CSX", "CTAS", "CTSH", "CVS", "CVX", "D", "DAI.DE", "DAL", "DASH", "DB1.DE",
+    "DBK.DE", "DD", "DDOG", "DE", "DFS", "DG", "DG.PA", "DGE.L", "DGX", "DHER.DE", "DHI",
+    "DHL.DE", "DHR", "DIS", "DLR", "DLTR", "DOV", "DOW", "DPW.DE", "DSM.AS", "DTE.DE",
+    "DTG.DE", "DUK", "DVN", "DXCM", "EA", "EBAY", "EIX", "EL", "EMN", "EN.PA", "ENB",
+    "ENB.TO", "ENEL.MI", "ENG.MC", "ENGI.PA", "ENI.MI", "ENPH", "ENR.DE", "EOAN.DE",
+    "EOG", "EQNR.OL", "EQR", "ERF.PA", "ES", "ESS", "ETN", "ETSY", "EW", "EXC", "EXPD",
+    "EXPE", "F", "FAST", "FDX", "FE", "FER.MC", "FFIV", "FIS", "FISV", "FITB", "FLG.MC",
+    "FLTR.L", "FME.DE", "FMG.AX", "FRE.DE", "FRES.L", "FSLR", "GD", "GE", "GGB", "GGBR4.SA",
+    "GIB-A.TO", "GILD", "GIS", "GIVN.SW", "GLE.PA", "GLW", "GM", "GMG.AX", "GOOG", "GOOGL",
+    "GPN", "GRF.MC", "GRMN", "GS", "GSK", "GSK.L", "GWW", "HAL", "HAS", "HBAN", "HCA",
+    "HCLTECH.NS", "HD", "HDFCBANK.NS", "HEI.DE", "HEIA.AS", "HEN3.DE", "HES", "HIK.L",
+    "HINDUNILVR.NS", "HLT", "HNR1.DE", "HOLN.SW", "HON", "HRL", "HSBA.L", "HSBC", "HSBC.L",
+    "HST", "HUM", "IAG.AX", "IAG.L", "IBE.MC", "IBM", "ICE", "ICICIBANK.NS", "IDR.MC",
+    "IDXX", "IEX", "IFX.DE", "IHG.L", "III.L", "ILMN", "IMCD.AS", "IMO.TO", "IMP.L",
+    "INF.L", "INFY.NS", "INGA.AS", "INTC", "INTU", "IP", "IPG", "IQV", "IR", "IRM", "ISP.MI",
+    "ISRG", "ITRK.L", "ITUB", "ITUB4.SA", "ITW", "ITX.MC", "IVZ", "JCI", "JD.L", "JNJ",
+    "JPM", "K", "KER.PA", "KEY", "KHC", "KIM", "KMB", "KMI", "KO", "KOTAKBANK.NS", "KPN.AS",
+    "KR", "L", "L.TO", "LAND.L", "LEG", "LGEN.L", "LH", "LHX", "LIN", "LIN.DE", "LLC.AX",
+    "LLOY.L", "LLY", "LMT", "LNT", "LOGN.SW", "LOW", "LR.PA", "LT.NS", "LUV", "LVMH.PA",
+    "LYB", "LYV", "M&M.NS", "MA", "MAP.MC", "MAR", "MARUTI.NS", "MAS", "MB.MI", "MBG.DE",
+    "MC.PA", "MCD", "MCHP", "MCK", "MCO", "MDB", "MDLZ", "MDT", "MEL.MC", "META", "MFC",
+    "MG.TO", "ML.PA", "MMC", "MMM", "MNG.L", "MNST", "MO", "MOS", "MPC", "MQG.AX", "MRK",
+    "MRK.DE", "MRL.MC", "MRO", "MRO.L", "MS", "MSCI", "MSFT", "MSI", "MTB", "MTD", "MTX.DE",
+    "MU", "MUV2.DE", "NAB.AX", "NCLH", "NCM.AX", "NDAQ", "NEE", "NEM", "NESN.SW", "NET",
+    "NFLX", "NG.L", "NI", "NKE", "NN.AS", "NOC", "NOVN.SW", "NOVO-B.CO", "NOW", "NRG", "NSC",
+    "NST.AX", "NTAP", "NTGY.MC", "NTR.TO", "NTRS", "NVDA", "NVR", "NWG.L", "NWL", "NWSA", "O",
+    "OCADO.L", "OKE", "OKTA", "OR.PA", "ORA.PA", "ORCL", "OXY", "P911.DE", "PAH3.DE", "PANW",
+    "PART.SW", "PATH", "PAYC", "PAYX", "PBR", "PCAR", "PDD", "PEG", "PEP", "PETR4.SA", "PFE",
+    "PFG", "PG", "PGR", "PH", "PHIA.AS", "PHM", "PHNX.L", "PINS", "PKG", "PLD", "PLTR", "PM",
+    "PNC", "PNR", "PNW", "POOL", "PPG", "PPL", "PRU", "PRU.L", "PRX.AS", "PSA", "PSN.L",
+    "PSON.L", "PSX", "PUB.PA", "PUM.DE", "PVH", "PWR", "PXD", "PYPL", "QAN.AX", "QBE.AX",
+    "QCOM", "QIA.DE", "QRVO", "RACE.MI", "RAND.AS", "RBLX", "RCL", "REG", "REGN", "RELIANCE.NS",
+    "REN.AS", "REP.MC", "RF", "RHI", "RHM.DE", "RI.PA", "RIO.AX", "RIO.L", "RL", "RMD",
+    "RMS.PA", "RNO.PA", "ROG.SW", "ROK", "ROKU", "ROL", "ROP", "ROST", "RR.L", "RSG", "RTO.L",
+    "RTX", "RWE.DE", "RY", "RY.TO", "SAF.PA", "SAN.MC", "SAN.PA", "SAP", "SAP.DE", "SBAC",
+    "SBIN.NS", "SBRY.L", "SBUX", "SCCO", "SCG.AX", "SCHW", "SCMN.SW", "SEDG", "SEE", "SGE.L",
+    "SGO.PA", "SGP.AX", "SGSN.SW", "SHEL", "SHEL.L", "SHELL.AS", "SHL.DE", "SHOP.TO", "SHW",
+    "SIE.DE", "SJM", "SLB", "SLF.TO", "SLHN.SW", "SMIN.L", "SMT.L", "SN.L", "SNA", "SNOW",
+    "SO", "SOFI", "SPG", "SPGI", "SPOT", "SQ", "SRE", "SREN.SW", "SRT3.DE", "SSE.L", "STAN.L",
+    "STE", "STLA", "STM.MI", "STO.AX", "STT", "STX", "STZ", "SU", "SU.PA", "SU.TO", "SUN.AX",
+    "SUNPHARMA.NS", "SWK", "SWKS", "SY1.DE", "SYK", "T", "T.TO", "TAP", "TATASTEEL.NS",
+    "TCL.AX", "TCS.NS", "TD", "TD.TO", "TDG", "TE.PA", "TEF.MC", "TEL", "TEN.MI", "TFC",
+    "TFX", "TGT", "TITAN.NS", "TJX", "TLS.AX", "TMO", "TMUS", "TRMB", "TRP", "TRP.TO", "TRV",
+    "TSCO", "TSCO.L", "TSLA", "TSN", "TT", "TTD", "TTE", "TTE.PA", "TWLO", "TXN", "TXT", "U",
+    "UAL", "UBSG.SW", "UCG.MI", "UDR", "UGI", "UHR.SW", "UL", "ULVR.L", "UMG.AS", "UMG.PA",
+    "UMPQ", "UNA.AS", "UNH", "UNP", "UPS", "UPST", "URI", "USB", "V", "VALE", "VALE3.SA",
+    "VFC", "VICI", "VIE.PA", "VIV.PA", "VLO", "VMC", "VNA.DE", "VNO", "VOD.L", "VOLV-B.ST",
+    "VOW3.DE", "VRSK", "VRSN", "VRTX", "VTR", "VZ", "WBA", "WBC.AX", "WBD", "WCN.TO", "WDAY",
+    "WDC", "WDS.AX", "WEC", "WEGE3.SA", "WELL", "WES.AX", "WFC", "WHR", "WIPRO.NS", "WKL.AS",
+    "WM", "WMB", "WMT", "WOW.AX", "WPM", "WRB", "WRK", "WST", "WTB.L", "WY", "WYNN", "XEL",
+    "XOM", "XRX", "XYL", "YUM", "ZAL.DE", "ZBH", "ZBRA", "ZION", "ZM", "ZS", "ZTS", "ZURN.SW"
+]
 
-# Wikipedia URLs for various global indices
-URL_SP500 = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
-URL_NASDAQ100 = "https://en.wikipedia.org/wiki/Nasdaq-100"
-URL_DAX = "https://en.wikipedia.org/wiki/DAX"
-URL_MDAX = "https://en.wikipedia.org/wiki/MDAX"
-URL_TECDAX_DE = "https://de.wikipedia.org/wiki/TecDAX"
-URL_SDAX_DE = "https://de.wikipedia.org/wiki/SDAX"
-URL_FTSE100 = "https://en.wikipedia.org/wiki/FTSE_100_Index"
-URL_CAC40 = "https://en.wikipedia.org/wiki/CAC_40"
-URL_NIKKEI225 = "https://en.wikipedia.org/wiki/Nikkei_225"
-URL_TSX_COMPOSITE = "https://en.wikipedia.org/wiki/List_of_companies_in_the_S%26P/TSX_Composite_Index"
-
-
-# --- Global Session ---
-session = requests.Session()
-session.headers.update({'User-Agent': 'RectifexStockScreener/1.2'})
-
-
-def _fetch_html(url):
-    """Fetches HTML content from a URL."""
-    try:
-        response = session.get(url, timeout=15)
-        response.raise_for_status()
-        return response.text
-    except requests.RequestException as e:
-        logging.error(f"Failed to fetch HTML from {url}: {e}")
-        return None
-
-# --- Ticker Scraping Functions for Each Index ---
-
-def get_sp500_tickers():
-    html = _fetch_html(URL_SP500)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        sp500_table = tables[0]
-        return sp500_table['Symbol'].str.replace('.', '-', regex=False).tolist()
-    except Exception as e:
-        logging.error(f"Could not parse S&P 500 table: {e}")
-        return []
-
-def get_nasdaq100_tickers():
-    html = _fetch_html(URL_NASDAQ100)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        nasdaq_table = tables[4]
-        return nasdaq_table['Ticker'].tolist()
-    except Exception as e:
-        logging.error(f"Could not parse Nasdaq 100 table: {e}")
-        return []
-
-def get_dax_tickers():
-    html = _fetch_html(URL_DAX)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        dax_table = tables[4]
-        return dax_table['Ticker'].tolist()
-    except Exception as e:
-        logging.error(f"Could not parse DAX table: {e}")
-        return []
-
-def get_mdax_tickers():
-    html = _fetch_html(URL_MDAX)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        mdax_table = tables[2]
-        tickers = mdax_table['Symbol'].dropna().tolist()
-        processed_tickers = [f"{t}.DE" if not any(t.endswith(s) for s in ['.DE','.LU','.PA','.AS']) else t for t in tickers if isinstance(t, str)]
-        return processed_tickers
-    except Exception as e:
-        logging.error(f"Could not parse MDAX table: {e}")
-        return []
-
-def get_ftse100_tickers():
-    html = _fetch_html(URL_FTSE100)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        ftse_table = tables[3]
-        return ftse_table['Ticker'].tolist()
-    except Exception as e:
-        logging.error(f"Could not parse FTSE 100 table: {e}")
-        return []
-
-def get_cac40_tickers():
-    html = _fetch_html(URL_CAC40)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        cac_table = tables[4]
-        return cac_table['Ticker'].tolist()
-    except Exception as e:
-        logging.error(f"Could not parse CAC 40 table: {e}")
-        return []
-
-def get_nikkei225_tickers():
-    html = _fetch_html(URL_NIKKEI225)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        nikkei_table = tables[1]
-        return (nikkei_table['Ticker symbol'].astype(str) + '.T').tolist()
-    except Exception as e:
-        logging.error(f"Could not parse Nikkei 225 table: {e}")
-        return []
-
-def get_tsx_composite_tickers():
-    html = _fetch_html(URL_TSX_COMPOSITE)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        tsx_table = tables[0]
-        return tsx_table['Symbol'].str.replace('.', '-', regex=False).tolist()
-    except Exception as e:
-        logging.error(f"Could not parse S&P/TSX Composite table: {e}")
-        return []
-
-# --- Functions requiring Yahoo Finance search (slower) ---
-
-def _search_ticker_yahoo(company_name):
-    search_url = f"https://query1.finance.yahoo.com/v1/finance/search"
-    params = {'q': company_name, 'quotesCount': 1, 'newsCount': 0}
-    try:
-        time.sleep(0.5)
-        response = session.get(search_url, params=params, timeout=15)
-        response.raise_for_status()
-        data = response.json()
-        if data.get('quotes'):
-            return data['quotes'][0]['symbol']
-    except Exception as e:
-        logging.error(f"Yahoo Finance search failed for '{company_name}': {e}")
-    return None
-
-def get_companies_from_german_wiki(url):
-    html = _fetch_html(url)
-    if not html: return []
-    try:
-        tables = pd.read_html(io.StringIO(html))
-        for table in tables:
-            if 'Name' in table.columns and 'Branche' in table.columns:
-                return table['Name'].str.replace(r'\[.*?\]', '', regex=True).str.strip().tolist()
-    except Exception as e:
-        logging.error(f"Could not parse table from {url}: {e}")
-    return []
-
-def get_tecdax_tickers():
-    companies = get_companies_from_german_wiki(URL_TECDAX_DE)
-    return [t for t in (_search_ticker_yahoo(c) for c in companies) if t]
-
-def get_sdax_tickers():
-    companies = get_companies_from_german_wiki(URL_SDAX_DE)
-    return [t for t in (_search_ticker_yahoo(c) for c in companies) if t]
-
-# --- Main Aggregator Function ---
-
-def get_all_tickers(force_refresh=False):
+def get_default_tickers():
     """
-    Aggregates tickers from all Wikipedia sources, using a cache file.
-    This function does NOT require an API key.
+    Returns the comprehensive, hardcoded list of global tickers provided by the user.
     """
-    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    if not force_refresh and CACHE_FILE.exists():
-        try:
-            with open(CACHE_FILE, 'r') as f:
-                data = json.load(f)
-                if datetime.datetime.now() - datetime.datetime.fromisoformat(data['date']) < datetime.timedelta(days=CACHE_DURATION_DAYS):
-                    logging.info("Loading tickers from cache.")
-                    return data['tickers']
-        except (json.JSONDecodeError, KeyError, ValueError):
-             logging.warning("Ticker cache file is invalid. Fetching fresh data.")
-
-    logging.info("Fetching fresh global ticker data from Wikipedia and Yahoo Finance.")
-    all_tickers = set()
-
-    # Add tickers from all implemented scrapers
-    all_tickers.update(get_sp500_tickers())
-    all_tickers.update(get_nasdaq100_tickers())
-    all_tickers.update(get_ftse100_tickers())
-    all_tickers.update(get_cac40_tickers())
-    all_tickers.update(get_nikkei225_tickers())
-    all_tickers.update(get_tsx_composite_tickers())
-    all_tickers.update(get_dax_tickers())
-    all_tickers.update(get_mdax_tickers())
-    all_tickers.update(get_tecdax_tickers())
-    all_tickers.update(get_sdax_tickers())
-
-    sorted_tickers = sorted(list(filter(None, all_tickers)))
-
-    logging.info(f"Saving {len(sorted_tickers)} global tickers to cache.")
-    with open(CACHE_FILE, 'w') as f:
-        json.dump({'date': datetime.datetime.now().isoformat(), 'tickers': sorted_tickers}, f)
-
-    return sorted_tickers
+    logging.info(f"Loading {len(DEFAULT_TICKER_LIST)} tickers from the default global list.")
+    return DEFAULT_TICKER_LIST


### PR DESCRIPTION
This commit implements the user's request to use a large, specific list of global stocks as the new default. This replaces the previous, unreliable Wikipedia scraping method.

Key changes:
- `ticker_fetcher.py` has been completely replaced with a module that provides the user's hardcoded list of ~500 global tickers.
- The UI in `main.py` has been simplified. The ticker source dropdown now only contains "Default Global List" and "Custom List", removing the obsolete individual index options.
- The `start_scan` logic in `main.py` is now much cleaner, directly calling the new ticker fetcher.

This change makes the application faster, more reliable, and provides the comprehensive global stock universe the user requested for the default `yfinance` scan path.