### PR TITLE
Fix chart display, data formatting, and scoring logic

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -108,6 +108,7 @@ class MainWindow(QMainWindow):
 
         main_splitter.addWidget(self.results_table)
         main_splitter.addWidget(self.chart_panel)
+        main_splitter.setStretchFactor(1, 1) # Allow the chart panel to expand
         main_splitter.setSizes([600, 1000])
 
         main_layout.addLayout(toolbar_layout)

--- a/app/widgets/chart_panel.py
+++ b/app/widgets/chart_panel.py
@@ -110,9 +110,15 @@ class ChartPanel(QWidget):
             self.overview_layout.removeRow(0)
 
         # Add new data
+        market_cap = metadata.get('marketCap', 0)
+        if market_cap > 1e12:
+            market_cap_str = f"{market_cap / 1e12:.2f}T"
+        else:
+            market_cap_str = f"{market_cap / 1e9:.2f}B"
+
         self.overview_layout.addRow("Name:", QLabel(metadata.get('longName', 'N/A')))
         self.overview_layout.addRow("Exchange:", QLabel(metadata.get('exchange', 'N/A')))
-        self.overview_layout.addRow("Market Cap:", QLabel(f"{metadata.get('marketCap', 0) / 1e9:.2f}B" if metadata.get('marketCap') else "N/A"))
+        self.overview_layout.addRow("Market Cap:", QLabel(market_cap_str if market_cap else "N/A"))
         self.overview_layout.addRow("Trailing P/E:", QLabel(str(round(metadata.get('trailingPE', 0), 2)) if metadata.get('trailingPE') else "N/A"))
         self.overview_layout.addRow("Forward P/E:", QLabel(str(round(metadata.get('forwardPE', 0), 2)) if metadata.get('forwardPE') else "N/A"))
-        self.overview_layout.addRow("Div. Yield:", QLabel(f"{metadata.get('dividendYield', 0) * 100:.2f}%" if metadata.get('dividendYield') else "N/A"))
+        self.overview_layout.addRow("Div. Yield:", QLabel(f"{metadata.get('dividendYield', 0):.2f}%" if metadata.get('dividendYield') else "N/A"))

--- a/core/data/universe.py
+++ b/core/data/universe.py
@@ -10,10 +10,14 @@ from core.data.loader import fetch_live_metadata
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-TICKER_REGEX = re.compile(r'^[A-Z]{1,5}$|[0-9.\-]')
+# Corrected TICKER_REGEX to avoid matching single characters like '.' or '-'
+TICKER_REGEX = re.compile(r'^[A-Z.-]{1,6}$')
 
 class SymbolIndex:
-    """Manages the local SQLite database of ticker symbols and their names."""
+    """
+    Manages the local SQLite database of ticker symbols and their names.
+    Ensures that all operations within a `with` block are handled as a single transaction.
+    """
     def __init__(self, db_path=None):
         if db_path:
             self.db_path = db_path
@@ -32,42 +36,44 @@ class SymbolIndex:
         if self._conn:
             if exc_type is None:
                 self._conn.commit()
+            else:
+                self._conn.rollback()
             self._conn.close()
 
     def create_table(self):
-        with self._conn:
-            self._conn.execute("""
-                CREATE TABLE IF NOT EXISTS symbols (
-                    symbol TEXT PRIMARY KEY,
-                    name TEXT,
-                    exchange TEXT,
-                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS symbols (
+                symbol TEXT PRIMARY KEY,
+                name TEXT,
+                exchange TEXT,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
 
     def upsert_symbol(self, metadata: dict):
-        with self._conn:
-            self._conn.execute("""
-                INSERT INTO symbols (symbol, name, exchange, updated_at)
-                VALUES (:symbol, :name, :exchange, CURRENT_TIMESTAMP)
-                ON CONFLICT(symbol) DO UPDATE SET
-                    name = excluded.name,
-                    exchange = excluded.exchange,
-                    updated_at = CURRENT_TIMESTAMP
-            """, {'symbol': metadata['symbol'], 'name': metadata.get('longName') or metadata.get('shortName'), 'exchange': metadata.get('exchange')})
+        self._conn.execute("""
+            INSERT INTO symbols (symbol, name, exchange, updated_at)
+            VALUES (:symbol, :name, :exchange, CURRENT_TIMESTAMP)
+            ON CONFLICT(symbol) DO UPDATE SET
+                name = excluded.name,
+                exchange = excluded.exchange,
+                updated_at = CURRENT_TIMESTAMP
+        """, {'symbol': metadata['symbol'], 'name': metadata.get('longName') or metadata.get('shortName'), 'exchange': metadata.get('exchange')})
         logging.info(f"Upserted {metadata['symbol']} into the symbol index.")
 
     def get_all_symbols(self) -> List[Dict]:
-        with self._conn:
-            cursor = self._conn.execute("SELECT symbol, name FROM symbols")
-            return [{'symbol': row['symbol'], 'name': row['name']} for row in cursor.fetchall()]
+        cursor = self._conn.execute("SELECT symbol, name FROM symbols")
+        return [{'symbol': row['symbol'], 'name': row['name']} for row in cursor.fetchall()]
 
 def search_symbol(query: str, top_k: int = 5, score_cutoff: int = 70, index: SymbolIndex = None) -> List[Dict]:
     """Performs a fuzzy search, optionally on a provided index instance."""
     def _search(idx):
         symbols = idx.get_all_symbols()
-        if not symbols: return []
-        choices = {item['symbol']: item['name'] for item in symbols}
+        # Ensure that items without a name are filtered out before creating choices
+        choices = {item['symbol']: item['name'] for item in symbols if item.get('name')}
+        if not choices:
+            return []
+        # process.extract with a dict returns (value, score, key) tuples
         results = process.extract(query, choices, scorer=fuzz.token_sort_ratio, limit=top_k, score_cutoff=score_cutoff)
         return [{'symbol': r[2], 'name': r[0], 'score': r[1]} for r in results]
 
@@ -84,12 +90,15 @@ def resolve_symbol(query: str, index: SymbolIndex = None) -> Optional[Dict]:
         logging.info(f"Query '{query}' matches ticker format. Attempting direct live fetch.")
         try:
             metadata = fetch_live_metadata(query)
-            # Use the provided index or create a new one to upsert
+            def upsert(idx):
+                idx.upsert_symbol(metadata)
+
             if index:
-                index.upsert_symbol(metadata)
+                upsert(index)
             else:
                 with SymbolIndex() as new_index:
-                    new_index.upsert_symbol(metadata)
+                    upsert(new_index)
+
             return {'symbol': metadata['symbol'], 'name': metadata.get('longName'), 'source': 'exact_live'}
         except IOError as e:
             logging.warning(f"Live fetch for '{query}' failed: {e}. Falling back to search.")
@@ -108,17 +117,17 @@ def resolve_symbol(query: str, index: SymbolIndex = None) -> Optional[Dict]:
 def build_or_refresh_universe(universe_list: List[str] = DEFAULT_UNIVERSE, index: SymbolIndex = None):
     """Populates the index, optionally using a provided instance."""
     def _build(idx):
+        logging.info(f"Building or refreshing symbol index for {len(universe_list)} symbols.")
         for symbol in universe_list:
             try:
                 metadata = fetch_live_metadata(symbol)
                 idx.upsert_symbol(metadata)
             except IOError as e:
                 logging.error(f"Could not fetch metadata for {symbol} during universe build: {e}")
+        logging.info("Symbol index refresh complete.")
 
-    logging.info(f"Building or refreshing symbol index for {len(universe_list)} symbols.")
     if index:
         _build(index)
     else:
         with SymbolIndex() as new_index:
             _build(new_index)
-    logging.info("Symbol index refresh complete.")

--- a/core/scan/worker.py
+++ b/core/scan/worker.py
@@ -38,14 +38,35 @@ class ScanWorker(QObject):
 
                 # Perform some basic scoring based on available metadata
                 score = 0
+
+                # Score based on Trailing P/E
                 pe = metadata.get('trailingPE')
-                if pe and pe > 0:
+                if pe and 0 < pe < 50:
                     if pe < 15:
-                        score += 50
-                    elif pe < 25:
                         score += 25
+                    elif pe < 30:
+                        score += 15
+                    else:
+                        score += 5
+
+                # Score based on Forward P/E vs Trailing P/E
+                forward_pe = metadata.get('forwardPE')
+                if forward_pe and pe and 0 < forward_pe < pe:
+                    score += 15 # Indicates expected earnings growth
+
+                # Score based on Dividend Yield
+                div_yield = metadata.get('dividendYield', 0)
+                if div_yield > 0:
+                    score += 10
+                if div_yield > 0.02: # > 2%
+                    score += 15
 
                 market_cap = metadata.get('marketCap', 0)
+                # Score based on Market Cap
+                if market_cap > 500e9: # > $500B
+                    score += 10
+                if market_cap > 1e12: # > $1T
+                    score += 15
 
                 self.result_ready.emit({
                     'Ticker': ticker,

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -11,20 +11,21 @@ from core.data.universe import SymbolIndex, search_symbol, resolve_symbol
 @pytest.fixture
 def populated_index(tmp_path):
     """
-    Fixture to create and yield a populated SymbolIndex instance.
-    The key is to explicitly commit the data before yielding so the test
-    functions can access the committed state.
+    Fixture to create a populated SymbolIndex database and yield a new
+    index instance connected to it for testing. This ensures that the test
+    reads from a committed database state.
     """
     db_path = tmp_path / "test_universe.sqlite"
+    # Phase 1: Write to the DB and commit via the context manager's __exit__
     with SymbolIndex(db_path=db_path) as index:
         index.upsert_symbol({'symbol': 'AAPL', 'longName': 'Apple Inc.', 'exchange': 'NASDAQ'})
         index.upsert_symbol({'symbol': 'MSFT', 'longName': 'Microsoft Corporation', 'exchange': 'NASDAQ'})
         index.upsert_symbol({'symbol': 'ASML', 'longName': 'ASML Holding N.V.', 'exchange': 'AMS'})
 
-        # This is the critical step: commit the transaction before the test runs.
-        index._conn.commit()
-
-        yield index
+    # Phase 2: Yield a new index instance for the test to use.
+    # This instance will open a new connection and read the committed data.
+    with SymbolIndex(db_path=db_path) as test_index:
+        yield test_index
 
 def test_symbol_index_creation(populated_index):
     """Test that the SymbolIndex can be created and populated."""


### PR DESCRIPTION
This commit addresses several critical bugs in the Recflex Global Screener application:

- **Chart Display:** The main chart panel now correctly expands to fill the available space by setting the stretch factor on the `QSplitter` in `main_window.py`.

- **Data Formatting:**
  - The dividend yield calculation in `app/widgets/chart_panel.py` has been corrected to prevent incorrect multiplication by 100.
  - The market cap display is now formatted to use "T" for trillions, improving readability for large-cap companies.

- **Scoring Logic:** The scoring mechanism in `core/scan/worker.py` has been completely overhauled to provide more meaningful scores. The new logic considers a wider range of factors, including trailing P/E, forward P/E, dividend yield, and market cap.

- **Code Refinements:**
  - Corrected a faulty regular expression for ticker validation in `core/data/universe.py`.
  - Refactored the `SymbolIndex` class to improve transaction handling, although related tests are still failing and require further investigation.