### PR TITLE
Fix chart crash and X-axis compression by using ax.set_xlim()

### DIFF
--- a/core/chart/service.py
+++ b/core/chart/service.py
@@ -111,13 +111,15 @@ class ChartService:
                 addplot=addplots,
                 panel_ratios=(3, 1) if panel_id > 1 else (1,0),
                 figscale=figscale,
-                returnfig=True,
-                x_range=x_range
+                returnfig=True
             )
+
+            # --- Correctly set X-axis limits to prevent compression ---
+            ax_main = self.ax[0]
+            ax_main.set_xlim(df_ohlcv.index[0], df_ohlcv.index[-1])
 
             # --- Fibonacci Lines ---
             if fib and options.get('show_fib'):
-                ax_main = self.ax[0]
                 for level_name, price in fib['levels'].items():
                     color = 'green' if 'Retrace' in level_name else 'purple'
                     ax_main.axhline(y=price, color=color, linestyle='--', linewidth=0.7, alpha=0.8)


### PR DESCRIPTION
This commit resolves a critical bug that caused the application to crash when generating a chart, and also fixes the underlying X-axis compression issue.

The crash was introduced by an incorrect attempt to use a non-existent `x_range` keyword argument in the `mplfinance.plot()` function.

The correct fix, implemented in this commit, is to use the `ax.set_xlim()` method on the Matplotlib Axes object that is returned by `mpf.plot()`. This correctly sets the visible date range on the chart, which resolves the original bug of the X-axis being compressed into a single vertical line.