### PR TITLE
Fix critical rendering issues by enabling software OpenGL

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -256,6 +256,9 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(f"Export failed: {e}", 10000)
 
 if __name__ == "__main__":
+    # Force software rendering to avoid potential GPU/driver conflicts
+    QApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()


### PR DESCRIPTION
This commit resolves a critical bug that caused severe graphical glitches, including a blank chart and distorted UI labels. These symptoms pointed to a GPU driver or hardware acceleration conflict.

The fix is to force the application to use a software-based renderer instead of relying on the native OpenGL drivers. This is achieved by setting the `Qt.AA_UseSoftwareOpenGL` attribute on the `QApplication` instance before it is initialized in `app/main_window.py`.

This change acts as a robust fallback, ensuring the application remains usable on systems where the GPU drivers are not compatible with Qt's hardware-accelerated rendering pipeline.