### PR TITLE
Fix critical rendering issues by forcing software OpenGL via env var

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Force software rendering to avoid potential GPU/driver conflicts
+export QT_OPENGL=software
 # Set the Python path to include the app's root directory
 export PYTHONPATH=/app
 # Run the main application


### PR DESCRIPTION
This commit resolves a critical bug that caused severe graphical glitches, including a blank chart and distorted UI labels. These symptoms pointed to a GPU driver or hardware acceleration conflict.

Previous attempts to fix this by setting the `Qt.AA_UseSoftwareOpenGL` attribute were unsuccessful. This commit implements a more forceful and reliable method.

The fix is to set the `QT_OPENGL=software` environment variable in the `start.sh` script before the application is launched. This ensures that Qt's underlying libraries use a software-based renderer from the very beginning, which effectively works around potential GPU driver conflicts and ensures the application remains usable on affected systems.