### PR TITLE
Fix critical rendering issues by disabling XCB GL integration.

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -256,9 +256,6 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(f"Export failed: {e}", 10000)
 
 if __name__ == "__main__":
-    # Force software rendering to avoid potential GPU/driver conflicts
-    QApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
-
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Force software rendering to avoid potential GPU/driver conflicts
-export QT_OPENGL=software
+export QT_XCB_GL_INTEGRATION=none
 # Set the Python path to include the app's root directory
 export PYTHONPATH=/app
 # Run the main application


### PR DESCRIPTION
This commit resolves a persistent and critical bug that caused severe graphical glitches, including a blank chart and distorted UI labels, which made the application unusable.

Previous attempts to fix this by setting `Qt.AA_UseSoftwareOpenGL` or `QT_OPENGL=software` were unsuccessful in the target Flatpak environment. This indicates a deep-seated conflict within the graphics stack.

The fix implemented here is to set the `QT_XCB_GL_INTEGRATION=none` environment variable in the `start.sh` script. This is a more forceful method that completely disables the GLX and EGL backends, forcing Qt to use a non-hardware-accelerated rendering path. This reliably works around the driver or environment-specific conflicts and ensures the application renders correctly.