### PR TITLE
Fix Flatpak runtime and implement Signals tab logic

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -220,6 +220,7 @@ class MainWindow(QMainWindow):
 
         self.chart_panel.update_chart(chart_path)
         self.chart_panel.update_overview(results['metadata'])
+        self.chart_panel.update_signals(results['signals'])
         self.chart_panel.set_stale_badge_visibility(results['is_stale'])
         self.chart_panel.export_button.setEnabled(True)
 

--- a/app/widgets/chart_panel.py
+++ b/app/widgets/chart_panel.py
@@ -2,6 +2,10 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QTabWidget, QLabel, QPushBu
                                QHBoxLayout, QGroupBox, QFormLayout, QCheckBox, QFrame, QSizePolicy)
 from PySide6.QtGui import QPixmap
 from PySide6.QtCore import Slot, Qt
+from typing import List
+
+# Import the Signal dataclass for type hinting
+from core.signals.engine import Signal
 
 class ChartPanel(QWidget):
     """
@@ -122,3 +126,36 @@ class ChartPanel(QWidget):
         self.overview_layout.addRow("Trailing P/E:", QLabel(str(round(metadata.get('trailingPE', 0), 2)) if metadata.get('trailingPE') else "N/A"))
         self.overview_layout.addRow("Forward P/E:", QLabel(str(round(metadata.get('forwardPE', 0), 2)) if metadata.get('forwardPE') else "N/A"))
         self.overview_layout.addRow("Div. Yield:", QLabel(f"{metadata.get('dividendYield', 0):.2f}%" if metadata.get('dividendYield') else "N/A"))
+
+    @Slot(list)
+    def update_signals(self, signals: List[Signal]):
+        """Populates the signals tab with the latest analysis."""
+        # Clear old widgets from the layout
+        while self.signals_layout.count():
+            child = self.signals_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+        if not signals:
+            self.signals_layout.addWidget(QLabel("No recent signals found."))
+            return
+
+        # Sort signals by date, most recent first
+        sorted_signals = sorted(signals, key=lambda s: s.ts, reverse=True)
+
+        for signal in sorted_signals:
+            # Create a visually distinct group box for each signal
+            signal_box = QGroupBox(f"{signal.ts.strftime('%Y-%m-%d')}: {signal.label}")
+            signal_box.setObjectName(f"SignalCard_{signal.direction.lower()}")
+
+            form_layout = QFormLayout(signal_box)
+            form_layout.addRow("Direction:", QLabel(signal.direction.capitalize()))
+            form_layout.addRow("Confidence:", QLabel(f"{signal.confidence:.0f} / 100"))
+
+            reason_label = QLabel(signal.reason)
+            reason_label.setWordWrap(True)
+            form_layout.addRow("Reason:", reason_label)
+
+            self.signals_layout.addWidget(signal_box)
+
+        self.signals_layout.addStretch(1)

--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -1,7 +1,7 @@
 app-id: io.github.BioVisualizer.Rectifex
-runtime: org.kde.Platform
-runtime-version: '6.7'
-sdk: org.kde.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
 command: start.sh
 
 build-options:


### PR DESCRIPTION
This commit addresses two critical issues:
1.  A persistent rendering bug causing graphical glitches and a blank chart.
2.  A non-functional "Signals" tab that never displayed any data.

The rendering issue was traced to an outdated and unsupported Flatpak runtime (`org.kde.Platform`). The fix was to update the `io.github.BioVisualizer.Rectifex.yml` manifest to use a modern, stable runtime (`org.freedesktop.Platform:23.08`), which provides a compatible graphics stack.

The "Signals" tab was fixed by implementing the necessary UI logic to display the signal data generated by the backend. This involved:
- Adding an `update_signals` method to `app/widgets/chart_panel.py` to dynamically create and populate signal cards.
- Calling this new method from `app/main_window.py` when the analysis for a stock is complete.