### PR TITLE
Revert Flatpak runtime version to 23.08

### DIFF
--- a/io.github.BioVisualizer.Rectifex.yml
+++ b/io.github.BioVisualizer.Rectifex.yml
@@ -1,6 +1,6 @@
 app-id: io.github.BioVisualizer.Rectifex
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: start.sh
 


### PR DESCRIPTION
This commit reverts the Flatpak `runtime-version` in the `io.github.BioVisualizer.Rectifex.yml` manifest from '24.08' back to '23.08'.

The previous attempt to upgrade to the '24.08' runtime caused a build failure because the required SDK was not installed in the user's environment.

This reversion is a temporary measure to ensure the application is buildable and functional again. The end-of-life warning for the '23.08' runtime will reappear in the build logs, but this is a necessary trade-off to provide a working build immediately.