### PR TITLE
Fix blank chart and incomplete overview data by correcting the data l…

### DIFF
--- a/core/data/loader.py
+++ b/core/data/loader.py
@@ -25,9 +25,15 @@ def fetch_live_ohlcv(symbol: str, period: str = "max", interval: str = "1d", ret
     ticker = yf.Ticker(symbol)
     for i in range(retries):
         try:
-            df = ticker.history(period=period, interval=interval, auto_adjust=True)
+            # Set auto_adjust=False to prevent column names from being lowercased.
+            # This ensures 'Open', 'High', 'Low', 'Close' are preserved for mplfinance.
+            df = ticker.history(period=period, interval=interval, auto_adjust=False)
             if df.empty:
                 raise ValueError(f"No data found for symbol {symbol}")
+
+            # Keep only the essential columns
+            df = df[['Open', 'High', 'Low', 'Close', 'Volume']]
+
             # Ensure the index is a DatetimeIndex
             df.index = pd.to_datetime(df.index)
             return df
@@ -40,7 +46,7 @@ def fetch_live_ohlcv(symbol: str, period: str = "max", interval: str = "1d", ret
 
 def fetch_live_metadata(symbol: str, retries: int = 3, backoff_factor: float = 0.8) -> dict:
     """
-    Fetches live metadata for a symbol, prioritizing fast_info and falling back to info.
+    Fetches live metadata for a symbol using the main `info` endpoint.
 
     Args:
         symbol: The stock ticker symbol.
@@ -56,26 +62,19 @@ def fetch_live_metadata(symbol: str, retries: int = 3, backoff_factor: float = 0
     ticker = yf.Ticker(symbol)
     for i in range(retries):
         try:
-            # yfinance fast_info is often quicker and has key financial data
-            info = ticker.fast_info
-            # If fast_info is limited, supplement with the full `info` dict
-            full_info = ticker.info
+            # The .info dictionary contains all the necessary metadata.
+            # This is simpler and more robust than merging fast_info and info.
+            info = ticker.info
 
-            metadata = {
-                'symbol': symbol,
-                'longName': full_info.get('longName', info.get('longName')),
-                'shortName': full_info.get('shortName'),
-                'exchange': full_info.get('exchange'),
-                'marketCap': full_info.get('marketCap'),
-                'trailingPE': full_info.get('trailingPE'),
-                'forwardPE': full_info.get('forwardPE'),
-                'dividendYield': full_info.get('dividendYield'),
-                'debtToEquity': full_info.get('debtToEquity'),
-                'currency': info.get('currency'),
-                'lastPrice': info.get('lastPrice')
-            }
-            # Filter out None values
-            metadata = {k: v for k, v in metadata.items() if v is not None}
+            # Ensure essential keys exist, even if their values are None.
+            # The UI layer is responsible for handling None and displaying "N/A".
+            required_keys = [
+                'longName', 'shortName', 'exchange', 'marketCap', 'trailingPE',
+                'forwardPE', 'dividendYield', 'debtToEquity', 'currency'
+            ]
+            metadata = {'symbol': symbol}
+            for key in required_keys:
+                metadata[key] = info.get(key)
 
             if not metadata.get('longName') and not metadata.get('shortName'):
                  raise ValueError(f"Could not resolve a name for symbol {symbol}")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -19,8 +19,14 @@ def mock_yfinance_ticker():
 
 def test_fetch_live_ohlcv_success(mock_yfinance_ticker):
     """Test successful fetching of OHLCV data."""
-    # Arrange: Mock the history method to return a valid DataFrame
-    mock_df = pd.DataFrame({'Close': [100, 101, 102]})
+    # Arrange: Mock the history method to return a valid DataFrame with all required columns
+    mock_df = pd.DataFrame({
+        'Open': [99, 100, 101],
+        'High': [101, 102, 103],
+        'Low': [98, 99, 100],
+        'Close': [100, 101, 102],
+        'Volume': [1e6, 1.1e6, 1.2e6]
+    }, index=pd.to_datetime(['2023-01-01', '2023-01-02', '2023-01-03']))
     mock_yfinance_ticker.history.return_value = mock_df
 
     # Act
@@ -28,13 +34,17 @@ def test_fetch_live_ohlcv_success(mock_yfinance_ticker):
 
     # Assert
     assert not df.empty
-    assert df.equals(mock_df)
+    # The function now returns a DataFrame with a DatetimeIndex, so we can do a full comparison
+    pd.testing.assert_frame_equal(df, mock_df)
     mock_yfinance_ticker.history.assert_called_once()
 
 def test_fetch_live_ohlcv_failure_with_retry(mock_yfinance_ticker):
     """Test that fetch_live_ohlcv retries on failure and eventually succeeds."""
-    # Arrange: Fail twice, then succeed
-    mock_yfinance_ticker.history.side_effect = [Exception("Network Error"), Exception("Throttled"), pd.DataFrame({'Close': [100]})]
+    # Arrange: Fail twice, then succeed with a valid DataFrame
+    mock_df_success = pd.DataFrame({
+        'Open': [99], 'High': [101], 'Low': [98], 'Close': [100], 'Volume': [1e6]
+    }, index=pd.to_datetime(['2023-01-01']))
+    mock_yfinance_ticker.history.side_effect = [Exception("Network Error"), Exception("Throttled"), mock_df_success]
 
     # Act
     df = fetch_live_ohlcv("AAPL", retries=3, backoff_factor=0.01) # Use small backoff for speed
@@ -55,31 +65,34 @@ def test_fetch_live_ohlcv_hard_failure(mock_yfinance_ticker):
 
 def test_fetch_live_metadata_success(mock_yfinance_ticker):
     """Test successful fetching of metadata."""
-    # Arrange
-    mock_yfinance_ticker.fast_info = {'lastPrice': 150, 'currency': 'USD'}
-    mock_yfinance_ticker.info = {'longName': 'Apple Inc.', 'exchange': 'NMS'}
+    # Arrange: Mock the .info attribute with a dictionary containing all expected keys
+    mock_info_data = {
+        'longName': 'Apple Inc.',
+        'exchange': 'NMS',
+        'marketCap': 2e12,
+        'trailingPE': 30.5,
+        'forwardPE': 25.5,
+        'dividendYield': 0.005,
+        'debtToEquity': 150.0,
+        'currency': 'USD'
+    }
+    mock_yfinance_ticker.info = mock_info_data
 
     # Act
     metadata = fetch_live_metadata("AAPL")
 
     # Assert
     assert metadata['longName'] == 'Apple Inc.'
-    assert metadata['lastPrice'] == 150
+    assert metadata['marketCap'] == 2e12
     assert metadata['exchange'] == 'NMS'
-    assert 'debtToEquity' not in metadata # Test that None values are filtered
+    # Check that a key with a value is present
+    assert 'debtToEquity' in metadata
 
 def test_fetch_live_metadata_failure(mock_yfinance_ticker):
     """Test that fetch_live_metadata raises an IOError after all retries fail."""
-    # Arrange
-    # Make .info a mock that returns None for any .get() call, forcing the failure
-    mock_yfinance_ticker.fast_info = {}
-    mock_info = MagicMock()
-    mock_info.get.return_value = None
-    mock_yfinance_ticker.info = mock_info
+    # Arrange: Mock the .info to raise an exception, simulating a network failure
+    mock_yfinance_ticker.info = Exception("Network error")
 
     # Act & Assert
     with pytest.raises(IOError, match="Failed to fetch metadata for AAPL after 3 retries."):
         fetch_live_metadata("AAPL", retries=3, backoff_factor=0.01)
-
-    # Assert that .get was called on the info object (e.g., for 'longName')
-    mock_yfinance_ticker.info.get.assert_any_call('longName', None)


### PR DESCRIPTION
…oader.

This commit addresses two critical bugs:
1.  **Blank Chart Display:** The chart was not rendering because `yfinance.history(auto_adjust=True)` was renaming the OHLC columns to lowercase (e.g., 'open'), which `mplfinance` could not recognize. The fix is to set `auto_adjust=False` and explicitly select the correctly capitalized columns.
2.  **Incomplete Overview Data:** The overview tab was missing data because the metadata fetching logic was unnecessarily complex and would discard keys with `None` values. This has been simplified to use the main `ticker.info` dictionary and to always pass all required keys to the UI, which is responsible for handling `None` values.

These changes ensure the data pipeline is robust and provides correctly formatted data to the UI, resolving the critical display bugs.