### PR TITLE
Fix Scan Worker crash on stocks with missing data

### DIFF
--- a/core/scan/worker.py
+++ b/core/scan/worker.py
@@ -54,27 +54,27 @@ class ScanWorker(QObject):
                 if forward_pe and pe and 0 < forward_pe < pe:
                     score += 15 # Indicates expected earnings growth
 
-                # Score based on Dividend Yield
-                div_yield = metadata.get('dividendYield', 0)
-                if div_yield > 0:
-                    score += 10
-                if div_yield > 0.02: # > 2%
-                    score += 15
+                # Score based on Dividend Yield, checking for None
+                div_yield = metadata.get('dividendYield')
+                if div_yield is not None:
+                    if div_yield > 0:
+                        score += 10
+                    if div_yield > 0.02:
+                        score += 15
 
-                market_cap = metadata.get('marketCap', 0)
-                # Score based on Market Cap
-                if market_cap > 500e9: # > $500B
-                    score += 10
-                if market_cap > 1e12: # > $1T
-                    score += 15
+                # Score and format Market Cap, checking for None
+                market_cap = metadata.get('marketCap')
+                market_cap_str = "N/A"
+                if market_cap is not None:
+                    if market_cap > 500e9:
+                        score += 10
+                    if market_cap > 1e12:
+                        score += 15
 
-                # Format market cap for display
-                if market_cap >= 1e12:
-                    market_cap_str = f"${market_cap / 1e12:.2f}T"
-                elif market_cap > 0:
-                    market_cap_str = f"${market_cap / 1e9:.1f}B"
-                else:
-                    market_cap_str = "N/A"
+                    if market_cap >= 1e12:
+                        market_cap_str = f"${market_cap / 1e12:.2f}T"
+                    elif market_cap > 0:
+                        market_cap_str = f"${market_cap / 1e9:.1f}B"
 
                 self.result_ready.emit({
                     'Ticker': ticker,


### PR DESCRIPTION
This commit resolves a critical bug that caused the "Run Full Scan" feature to crash when processing tickers with missing financial data (e.g., AMZN, TSLA).

The `TypeError` was caused by attempting numerical comparisons on `None` values returned by the `yfinance` API for metrics like `dividendYield` and `marketCap`.

The fix adds robust `None` checks to the scoring logic in `core/scan/worker.py`. The application now only performs comparisons and calculations on these metrics if they have a non-None value, preventing the crash and allowing the full scan to complete successfully.