### PR TITLE
Fix incorrect swing low calculation in Fibonacci indicator

### DIFF
--- a/core/indicators/fib.py
+++ b/core/indicators/fib.py
@@ -68,14 +68,14 @@ def auto_fib_levels(high: pd.Series, low: pd.Series, close: pd.Series, mode: str
             else: # Potential uptrend
                  # Find lowest low before the high
                  anchor_low_price = lookback_low[lookback_low.index <= anchor_high_date].min()
-                 anchor_low_date = lookback_low[lookback_low.index <= anchor_high_date].idxmax()
+                 anchor_low_date = lookback_low[lookback_low.index <= anchor_high_date].idxmin()
 
 
     if mode == "last_swing":
         anchor_high_price = lookback_high.max()
         anchor_high_date = lookback_high.idxmax()
         anchor_low_price = lookback_low.min()
-        anchor_low_date = lookback_low.idxmax()
+        anchor_low_date = lookback_low.idxmin()
 
     # Determine trend direction
     is_uptrend = anchor_high_date > anchor_low_date


### PR DESCRIPTION
This commit resolves a critical bug in the automatic Fibonacci level calculation in `core/indicators/fib.py`.

The logic was incorrectly using `idxmax()` to find the date of the swing low, which resulted in it selecting the *highest* low within the lookback period instead of the *lowest* low. This completely distorted the Fibonacci levels rendered on the chart.

The fix replaces the two erroneous `idxmax()` calls with `idxmin()`, ensuring that the correct lowest low is used for the calculation. This provides an accurate and meaningful Fibonacci overlay.