### PR TITLE
fix(chart): Remove manual x-limit to fix rendering

### DIFF
--- a/core/chart/service.py
+++ b/core/chart/service.py
@@ -114,10 +114,6 @@ class ChartService:
                 returnfig=True
             )
 
-            # --- Correctly set X-axis limits to prevent compression ---
-            ax_main = self.ax[0]
-            ax_main.set_xlim(df_ohlcv.index[0], df_ohlcv.index[-1])
-
             # --- Fibonacci Lines ---
             if fib and options.get('show_fib'):
                 for level_name, price in fib['levels'].items():


### PR DESCRIPTION
The candlestick series was not visible in the chart because the entire data history was being compressed into the view, making the candles too thin to see.

This change removes the manual setting of the x-axis limits, allowing mplfinance to use its default behavior of displaying a smaller, more recent window of the data. This restores the visibility of the chart data.