### PR TITLE
fix(chart): Correct chart rendering and fix NameError

### DIFF
--- a/core/chart/service.py
+++ b/core/chart/service.py
@@ -116,6 +116,7 @@ class ChartService:
 
             # --- Fibonacci Lines ---
             if fib and options.get('show_fib'):
+                ax_main = self.ax[0]
                 for level_name, price in fib['levels'].items():
                     color = 'green' if 'Retrace' in level_name else 'purple'
                     ax_main.axhline(y=price, color=color, linestyle='--', linewidth=0.7, alpha=0.8)


### PR DESCRIPTION
This commit addresses two issues:
1. The candlestick series was not visible because manually setting the x-axis limits to the full data range compressed the candles into invisibility. This was fixed by removing the manual `set_xlim` call.
2. A subsequent `NameError` occurred because the `ax_main` variable, used for drawing Fibonacci levels, was no longer defined. This is corrected by defining `ax_main` within the scope where it's used.