### PR TITLE
fix(config): Force software rendering via environment variables

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Force software rendering to avoid potential GPU/driver conflicts
+export QT_OPENGL=software
 export QT_XCB_GL_INTEGRATION=none
 # Set the Python path to include the app's root directory
 export PYTHONPATH=/app


### PR DESCRIPTION
This commit attempts to resolve a persistent chart compression bug by forcing the application to use software-based rendering instead of hardware-accelerated rendering. This is intended to bypass potential GPU/driver conflicts on the user's system.

The `start.sh` script is modified to include both `QT_OPENGL=software` and `QT_XCB_GL_INTEGRATION=none` environment variables. Using both variables provides the strongest possible instruction to Qt to avoid hardware acceleration, which is suspected to be the root cause of the visual glitch.