### PR TITLE
Fix(search): Correct fuzzy search logic to restore functionality

### DIFF
--- a/core/data/universe.py
+++ b/core/data/universe.py
@@ -66,16 +66,26 @@ class SymbolIndex:
         return [{'symbol': row['symbol'], 'name': row['name']} for row in cursor.fetchall()]
 
 def search_symbol(query: str, top_k: int = 5, score_cutoff: int = 70, index: SymbolIndex = None) -> List[Dict]:
-    """Performs a fuzzy search, optionally on a provided index instance."""
+    """
+    Performs a fuzzy search against both symbol and name, optionally on a provided index instance.
+    """
     def _search(idx):
         symbols = idx.get_all_symbols()
-        # Ensure that items without a name are filtered out before creating choices
-        choices = {item['symbol']: item['name'] for item in symbols if item.get('name')}
-        if not choices:
+        # Create a mapping from symbol to name for all valid symbols
+        symbol_to_name = {item['symbol']: item['name'] for item in symbols if item.get('name')}
+        if not symbol_to_name:
             return []
+
+        # Create choices for fuzzy search, converting to lowercase for case-insensitivity
+        choices = {symbol: f"{symbol} {name}".lower() for symbol, name in symbol_to_name.items()}
+
         # process.extract with a dict returns (value, score, key) tuples
-        results = process.extract(query, choices, scorer=fuzz.token_sort_ratio, limit=top_k, score_cutoff=score_cutoff)
-        return [{'symbol': r[2], 'name': r[0], 'score': r[1]} for r in results]
+        # where value is the search string ("aapl apple inc."), and key is the symbol ("AAPL")
+        # Use partial_token_sort_ratio to correctly match subsets (e.g., "Apple" in "AAPL Apple Inc.")
+        results = process.extract(query.lower(), choices, scorer=fuzz.partial_token_sort_ratio, limit=top_k, score_cutoff=score_cutoff)
+
+        # Reconstruct the results with the clean, original name
+        return [{'symbol': r[2], 'name': symbol_to_name[r[2]], 'score': r[1]} for r in results]
 
     if index:
         return _search(index)


### PR DESCRIPTION
This commit fixes a critical bug that made the single-stock quick search non-functional, which in turn prevented stock charts from ever being displayed.

The root cause was a flawed fuzzy search implementation in `core/data/universe.py`. The search function was using an inappropriate scoring method (`fuzz.token_sort_ratio`) and was case-sensitive, which caused queries for both ticker symbols (e.g., "AAPL") and company names (e.g., "Microsoft") to fail.

The following changes have been made to `search_symbol`:
1.  The search scorer has been changed to `fuzz.partial_token_sort_ratio`, which is designed to correctly match queries that are a subset of the search target (e.g., "Apple" within "AAPL Apple Inc.").
2.  The search is now case-insensitive by converting both the query and the search choices to lowercase before comparison.

These corrections restore the quick search functionality, allowing users to select stocks and view their corresponding charts, thus resolving the "black chart" bug.