### PR TITLE
Fix(search): Enable search for single-character tickers

### DIFF
--- a/app/widgets/search_bar.py
+++ b/app/widgets/search_bar.py
@@ -66,7 +66,7 @@ class SearchBar(QWidget):
 
     def on_text_changed(self, text: str):
         """When text changes, restart the search timer."""
-        if len(text) > 1:
+        if len(text) > 0:
             self.search_timer.start()
         else:
             self.completer.popup().hide()


### PR DESCRIPTION
This commit fixes a critical bug that prevented the single-stock quick search from working for tickers with only one character (e.g., "O" for Realty Income).

The `on_text_changed` method in the `SearchBar` widget was configured to only trigger a search if the input length was greater than one. This meant single-character tickers were always ignored, preventing the user from selecting them and viewing their chart.

The condition has been changed from `len(text) > 1` to `len(text) > 0`. This ensures that a search is triggered for any non-empty input, restoring the intended functionality and resolving the downstream "black chart" symptom for these specific tickers.