### PR TITLE
Improve chart panel controls and ticker resolution fallback

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -109,6 +109,7 @@ class MainWindow(QMainWindow):
 
         self.apply_theme()
         self.latest_analysis_results = None
+        self.current_symbol = None
         self.chart_service = ChartService() # Chart service now lives on the main thread
 
         central_widget = QWidget()
@@ -148,6 +149,8 @@ class MainWindow(QMainWindow):
 
         self.search_bar.symbolSelected.connect(self.start_symbol_resolution)
         self.chart_panel.export_button.clicked.connect(self.export_analysis_to_excel)
+        self.chart_panel.chartOptionsChanged.connect(self.on_chart_options_changed)
+        self.chart_panel.reloadRequested.connect(self.on_chart_reload_requested)
         self.scan_button.clicked.connect(self.start_full_scan)
         self.results_table.cellDoubleClicked.connect(self.on_table_double_click)
 
@@ -196,6 +199,7 @@ class MainWindow(QMainWindow):
     @Slot(str)
     def start_analysis_for_symbol(self, symbol: str):
         if not symbol: return
+        self.current_symbol = symbol
         self.statusBar().showMessage(f"Fetching live data for {symbol}...")
         self.thread = QThread()
         self.worker = DataWorker(symbol)
@@ -208,6 +212,7 @@ class MainWindow(QMainWindow):
         self.worker.results_ready.connect(self.on_analysis_complete)
         self.worker.error.connect(self.on_analysis_error)
 
+        self.chart_panel.reload_button.setEnabled(False)
         self.thread.start()
 
     @Slot()
@@ -260,22 +265,12 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage("Analysis complete.", 5000)
         self.latest_analysis_results = results
 
-        # --- Charting now happens on the main thread ---
-        ohlcv_for_chart = results['ohlcv'].tail(252)
-        indicators_for_chart = {k: v.tail(252) for k, v in results['indicators'].items() if hasattr(v, 'tail')}
-        chart_options = {
-            'show_ema_ribbon': True, 'show_bbands': True, 'show_vwap': True,
-            'show_rsi': True, 'show_macd': True, 'show_fib': True,
-            'bb_len': 20, 'bb_std': 2.0
-        }
-        chart_path = self.chart_service.draw(results['symbol'], ohlcv_for_chart, indicators_for_chart, results['fib_data'], chart_options)
-        self.latest_analysis_results['chart_path'] = chart_path # Update for export
-
-        self.chart_panel.update_chart(chart_path)
+        self.refresh_chart()
         self.chart_panel.update_overview(results['metadata'])
         self.chart_panel.update_signals(results['signals'])
         self.chart_panel.set_stale_badge_visibility(results['is_stale'])
         self.chart_panel.export_button.setEnabled(True)
+        self.chart_panel.reload_button.setEnabled(True)
 
     @Slot(str)
     def on_analysis_error(self, error_message: str):
@@ -283,6 +278,7 @@ class MainWindow(QMainWindow):
         self.chart_panel.chart_view.setText(f"Analysis failed for symbol.\nError: {error_message}")
         self.chart_panel.export_button.setEnabled(False)
         self.latest_analysis_results = None
+        self.chart_panel.reload_button.setEnabled(True)
 
     @Slot()
     def export_analysis_to_excel(self):
@@ -308,6 +304,38 @@ class MainWindow(QMainWindow):
         except Exception as e:
             logging.error(f"Excel export failed: {e}")
             self.statusBar().showMessage(f"Export failed: {e}", 10000)
+
+    def refresh_chart(self):
+        """Regenerates the chart image using the latest analysis data and UI options."""
+        if not self.latest_analysis_results:
+            return
+
+        chart_options = self.chart_panel.get_chart_options()
+        ohlcv_for_chart = self.latest_analysis_results['ohlcv'].tail(252)
+        indicators_for_chart = {
+            k: (v.tail(252) if hasattr(v, 'tail') else v)
+            for k, v in self.latest_analysis_results['indicators'].items()
+        }
+        chart_path = self.chart_service.draw(
+            self.latest_analysis_results['symbol'],
+            ohlcv_for_chart,
+            indicators_for_chart,
+            self.latest_analysis_results['fib_data'],
+            chart_options,
+        )
+
+        if chart_path:
+            self.latest_analysis_results['chart_path'] = chart_path
+            self.chart_panel.update_chart(chart_path)
+
+    @Slot(dict)
+    def on_chart_options_changed(self, _options: dict):
+        self.refresh_chart()
+
+    @Slot()
+    def on_chart_reload_requested(self):
+        if self.current_symbol:
+            self.start_analysis_for_symbol(self.current_symbol)
 
 if __name__ == "__main__":
     # Force software-based OpenGL rendering to avoid graphics driver issues.

--- a/app/widgets/chart_panel.py
+++ b/app/widgets/chart_panel.py
@@ -12,11 +12,11 @@ from PySide6.QtWidgets import (
     QSizePolicy,
 )
 from PySide6.QtGui import QPixmap
-from PySide6.QtCore import Slot, Qt
+from PySide6.QtCore import Slot, Qt, Signal
 from typing import List
 
 # Import the Signal dataclass for type hinting
-from core.signals.engine import Signal
+from core.signals.engine import Signal as SignalModel
 
 class ChartPanel(QWidget):
     """
@@ -45,7 +45,7 @@ class ChartPanel(QWidget):
         self.stale_badge.setVisible(False)
 
         chart_layout = QVBoxLayout()
-        chart_layout.addWidget(self.chart_view)
+        chart_layout.addWidget(self.chart_view, stretch=1)
         chart_layout.addWidget(self.stale_badge, alignment=Qt.AlignRight)
 
 
@@ -66,6 +66,9 @@ class ChartPanel(QWidget):
         self.cb_vwap = QCheckBox("VWAP")
         self.cb_rsi = QCheckBox("RSI Pane")
         self.cb_macd = QCheckBox("MACD Pane")
+
+        for checkbox in (self.cb_ema_ribbon, self.cb_bbands, self.cb_vwap, self.cb_rsi, self.cb_macd):
+            checkbox.setChecked(True)
         indicators_layout.addRow(self.cb_ema_ribbon)
         indicators_layout.addRow(self.cb_bbands)
         indicators_layout.addRow(self.cb_vwap)
@@ -76,6 +79,7 @@ class ChartPanel(QWidget):
         self.fib_tab = QWidget()
         fib_layout = QFormLayout(self.fib_tab)
         self.cb_fib_levels = QCheckBox("Show Fibonacci Levels")
+        self.cb_fib_levels.setChecked(True)
         fib_layout.addRow(self.cb_fib_levels)
 
         # Signals Tab
@@ -98,10 +102,49 @@ class ChartPanel(QWidget):
         toolbar_layout.addWidget(self.export_button)
 
         # --- Assembly ---
-        main_layout.addLayout(chart_layout)
+        main_layout.addLayout(chart_layout, stretch=3)
         main_layout.addLayout(toolbar_layout)
-        main_layout.addWidget(self.tab_widget)
+        main_layout.addWidget(self.tab_widget, stretch=2)
         self.setLayout(main_layout)
+
+        # --- Signals ---
+        for checkbox in (
+            self.cb_ema_ribbon,
+            self.cb_bbands,
+            self.cb_vwap,
+            self.cb_rsi,
+            self.cb_macd,
+            self.cb_fib_levels,
+        ):
+            checkbox.toggled.connect(self._emit_chart_options)
+
+        self.reload_button.clicked.connect(self._on_reload_clicked)
+
+    chartOptionsChanged = Signal(dict)
+    reloadRequested = Signal()
+
+    def get_chart_options(self) -> dict:
+        """Return the current state of the chart related controls."""
+        return {
+            "show_ema_ribbon": self.cb_ema_ribbon.isChecked(),
+            "show_bbands": self.cb_bbands.isChecked(),
+            "show_vwap": self.cb_vwap.isChecked(),
+            "show_rsi": self.cb_rsi.isChecked(),
+            "show_macd": self.cb_macd.isChecked(),
+            "show_fib": self.cb_fib_levels.isChecked(),
+            "bb_len": 20,
+            "bb_std": 2.0,
+        }
+
+    @Slot()
+    def _emit_chart_options(self):
+        """Notify listeners whenever the chart options change."""
+        self.chartOptionsChanged.emit(self.get_chart_options())
+
+    @Slot()
+    def _on_reload_clicked(self):
+        """Request a live reload of the currently displayed symbol."""
+        self.reloadRequested.emit()
 
     @Slot(str)
     def update_chart(self, image_path: str):
@@ -166,7 +209,7 @@ class ChartPanel(QWidget):
         self.overview_layout.addRow("Div. Yield:", QLabel(format_value(metadata.get('dividendYield'), lambda v: f"{v * 100:.2f}%")))
 
     @Slot(list)
-    def update_signals(self, signals: List[Signal]):
+    def update_signals(self, signals: List[SignalModel]):
         """Populates the signals tab with the latest analysis."""
         # Clear old widgets from the layout
         while self.signals_layout.count():

--- a/core/data/universe.py
+++ b/core/data/universe.py
@@ -96,10 +96,12 @@ def search_symbol(query: str, top_k: int = 5, score_cutoff: int = 70, index: Sym
 def resolve_symbol(query: str, index: SymbolIndex = None) -> Optional[Dict]:
     """Resolves a query, optionally using a provided index instance."""
     query = query.strip().upper()
+    manual_fallback = None
     if TICKER_REGEX.search(query):
         logging.info(f"Query '{query}' matches ticker format. Attempting direct live fetch.")
         try:
             metadata = fetch_live_metadata(query)
+
             def upsert(idx):
                 idx.upsert_symbol(metadata)
 
@@ -112,7 +114,7 @@ def resolve_symbol(query: str, index: SymbolIndex = None) -> Optional[Dict]:
             return {'symbol': metadata['symbol'], 'name': metadata.get('longName'), 'source': 'exact_live'}
         except IOError as e:
             logging.warning(f"Live fetch for '{query}' failed: {e}. Falling back to search.")
-            pass
+            manual_fallback = {'symbol': query, 'name': query, 'source': 'manual_entry'}
 
     logging.info(f"Performing fuzzy search for '{query}'.")
     search_results = search_symbol(query, top_k=1, index=index)
@@ -120,6 +122,10 @@ def resolve_symbol(query: str, index: SymbolIndex = None) -> Optional[Dict]:
         resolved = search_results[0]
         logging.info(f"Resolved '{query}' to '{resolved['symbol']}' via fuzzy search with score {resolved['score']}.")
         return {'symbol': resolved['symbol'], 'name': resolved['name'], 'source': 'fuzzy_cache'}
+
+    if manual_fallback:
+        logging.info(f"Using user-provided ticker '{manual_fallback['symbol']}' despite missing live metadata.")
+        return manual_fallback
 
     logging.error(f"Could not resolve query: '{query}'. No exact match or confident fuzzy result.")
     return None


### PR DESCRIPTION
## Summary
- make the chart panel layout expand with the window and expose indicator toggles as signals
- refresh single-stock charts on the main thread when options change and wire up the reload control
- allow manual ticker fallback when live metadata fails so quick search still resolves user input

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e786736b90832f8f1fad7fa26da861